### PR TITLE
style: update gmail label colors

### DIFF
--- a/app/src/routes/account/profile/create/+page.svelte
+++ b/app/src/routes/account/profile/create/+page.svelte
@@ -11,9 +11,6 @@
 	// Validate on mobile!! Use redirect flow if necessary
 	// Add 'interest in job opportunities' dropdown to waitlist
 	// Trigger welcome email!
-	// Change label color to @SRC #4986e7 and white
-	// Change label color to @SRC/Job Opportunity #c9daf8 (background) and #1c4587 (text)
-	// Update watch cloud function to use filter action
 
 	// Design
 	// Create separate layouts for (marketing) and (account) pages

--- a/cloudfunctions/collect_examples/emails.go
+++ b/cloudfunctions/collect_examples/emails.go
@@ -14,7 +14,7 @@ func getSRCEmails(srv *gmail.Service, userID string, startDate time.Time, pageTo
 	builder := srv.Users.Messages.List(userID).PageToken(pageToken).MaxResults(maxResults)
 
 	// always ignore sent emails
-	q := fmt.Sprintf("-label:sent label:%s", mail.SRC_JobOpportunityLabel)
+	q := fmt.Sprintf("-label:sent label:%s", mail.SRCJobOpportunityLabel)
 	if !startDate.IsZero() {
 		// start the search from the start date
 		q = fmt.Sprintf("%s after:%s", q, startDate.Format("2006/01/02"))

--- a/cloudfunctions/email_push_notifications/emails.go
+++ b/cloudfunctions/email_push_notifications/emails.go
@@ -46,7 +46,7 @@ func getNewEmailsSinceDate(srv *gmail.Service, userID string, date time.Time, la
 		labelID = defaultLabelID
 	}
 
-	q := fmt.Sprintf("-label:%s after:%s", mail.SRC_JobOpportunityLabel, date.Format("2006/01/02"))
+	q := fmt.Sprintf("-label:%s after:%s", mail.SRCJobOpportunityLabel, date.Format("2006/01/02"))
 
 	r, err := srv.Users.Messages.
 		List(userID).

--- a/cloudfunctions/full_email_sync/emails.go
+++ b/cloudfunctions/full_email_sync/emails.go
@@ -15,7 +15,7 @@ const maxResults = 250
 // Use the next page token to fetch the rest of the emails
 func getEmailsSinceDate(srv *gmail.Service, userID string, date time.Time, pageToken string) ([]*gmail.Message, string, error) {
 	// get all (including archived) emails after the start date, ignore sent emails and emails already processed by SRC
-	q := fmt.Sprintf("-label:sent -label:%s after:%s", mail.SRC_JobOpportunityLabel, date.Format("2006/01/02"))
+	q := fmt.Sprintf("-label:sent -label:%s after:%s", mail.SRCJobOpportunityLabel, date.Format("2006/01/02"))
 
 	r, err := srv.Users.Messages.
 		List(userID).

--- a/libs/gmail/label.go
+++ b/libs/gmail/label.go
@@ -5,14 +5,22 @@ import (
 )
 
 const (
-	SRC_Label                    = "@SRC"
-	SRC_JobOpportunityLabel      = "@SRC/Job Opportunity"
-	SRC_Color                    = "#ff7537"
-	SRC_JobOpportunityLabelColor = "#16a765"
-	white                        = "#ffffff"
+	SRCLabel               = "@SRC"
+	SRCJobOpportunityLabel = "@SRC/Job Opportunity"
 )
 
-func GetOrCreateLabel(srv *gmail.Service, userID string, labelID string, backgroundColor string, textColor string) (*gmail.Label, error) {
+var (
+	SRCLabelColor = &gmail.LabelColor{
+		BackgroundColor: "#4986e7",
+		TextColor:       "#ffffff",
+	}
+	SRCJobOpportunityLabelColor = &gmail.LabelColor{
+		BackgroundColor: "#c9daf8",
+		TextColor:       "#1c4587",
+	}
+)
+
+func GetOrCreateLabel(srv *gmail.Service, userID string, labelID string, color *gmail.LabelColor) (*gmail.Label, error) {
 	labels, err := srv.Users.Labels.List(userID).Do()
 
 	if err != nil {
@@ -25,10 +33,7 @@ func GetOrCreateLabel(srv *gmail.Service, userID string, labelID string, backgro
 		}
 	}
 
-	label, err := srv.Users.Labels.Create(userID, &gmail.Label{Name: labelID, Color: &gmail.LabelColor{
-		BackgroundColor: backgroundColor,
-		TextColor:       textColor,
-	}}).Do()
+	label, err := srv.Users.Labels.Create(userID, &gmail.Label{Name: labelID, Color: color}).Do()
 
 	if err != nil {
 		return nil, err
@@ -38,9 +43,9 @@ func GetOrCreateLabel(srv *gmail.Service, userID string, labelID string, backgro
 }
 
 func GetOrCreateSRCLabel(srv *gmail.Service, userID string) (*gmail.Label, error) {
-	return GetOrCreateLabel(srv, userID, SRC_Label, SRC_Color, white)
+	return GetOrCreateLabel(srv, userID, SRCLabel, SRCLabelColor)
 }
 
 func GetOrCreateSRCJobOpportunityLabel(srv *gmail.Service, userID string) (*gmail.Label, error) {
-	return GetOrCreateLabel(srv, userID, SRC_JobOpportunityLabel, SRC_JobOpportunityLabelColor, white)
+	return GetOrCreateLabel(srv, userID, SRCJobOpportunityLabel, SRCJobOpportunityLabelColor)
 }


### PR DESCRIPTION
### Description

Change to follow the same blue colors scheme we are using on the website. This will likely change again in the future. Also renames vars to be more idiomatic Go without the `_`

