### PR TITLE
refactor: move to new v1 classifier API

### DIFF
--- a/cloudfunctions/email_push_notifications/classifier_test.go
+++ b/cloudfunctions/email_push_notifications/classifier_test.go
@@ -15,8 +15,12 @@ func TestClassifierClientPredict(t *testing.T) {
 	ctx := context.Background()
 	apiKey := "test"
 	authToken := "xxx.yyy.zzz"
-	path := "/predict"
-	input := "input"
+	path := "/v1/predict"
+	input := &PredictRequest{
+		From:    "from",
+		Subject: "subject",
+		Body:    "body",
+	}
 	want := true
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -26,9 +30,6 @@ func TestClassifierClientPredict(t *testing.T) {
 		if r.URL.Path != path {
 			t.Errorf("got %v, want %v", r.URL.Path, path)
 		}
-		if r.Header.Get("X-API-KEY") != apiKey {
-			t.Errorf("got %v, want %v", r.Header.Get("X-API-KEY"), apiKey)
-		}
 		wantAuth := fmt.Sprintf("Bearer %s", authToken)
 		if r.Header.Get("Authorization") != wantAuth {
 			t.Errorf("got %v, want %v", r.Header.Get("Authorization"), wantAuth)
@@ -37,8 +38,14 @@ func TestClassifierClientPredict(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Errorf("failed to decode request body: %v", err)
 		}
-		if body.Input != input {
-			t.Errorf("got %v, want %v", body.Input, input)
+		if body.From != input.From {
+			t.Errorf("got %v, want %v", body.From, input.From)
+		}
+		if body.Subject != input.Subject {
+			t.Errorf("got %v, want %v", body.Subject, input.Subject)
+		}
+		if body.Body != input.Body {
+			t.Errorf("got %v, want %v", body.Body, input.Body)
 		}
 		resp := PredictResponse{
 			Result: want,
@@ -68,10 +75,18 @@ func TestClassifierClientPredictBatch(t *testing.T) {
 	ctx := context.Background()
 	apiKey := "test"
 	authToken := "xxx.yyy.zzz"
-	path := "/predict/batch"
-	inputs := map[string]string{
-		"input1": "input1",
-		"input2": "input2",
+	path := "/v1/predict/batch"
+	inputs := map[string]*PredictRequest{
+		"input1": &PredictRequest{
+			From:    "1",
+			Subject: "1",
+			Body:    "1",
+		},
+		"input2": &PredictRequest{
+			From:    "2",
+			Subject: "2",
+			Body:    "2",
+		},
 	}
 	want := map[string]bool{
 		"input1": true,
@@ -85,9 +100,6 @@ func TestClassifierClientPredictBatch(t *testing.T) {
 		if r.URL.Path != path {
 			t.Errorf("got %v, want %v", r.URL.Path, path)
 		}
-		if r.Header.Get("X-API-KEY") != apiKey {
-			t.Errorf("got %v, want %v", r.Header.Get("X-API-KEY"), apiKey)
-		}
 		wantAuth := fmt.Sprintf("Bearer %s", authToken)
 		if r.Header.Get("Authorization") != wantAuth {
 			t.Errorf("got %v, want %v", r.Header.Get("Authorization"), wantAuth)
@@ -97,8 +109,14 @@ func TestClassifierClientPredictBatch(t *testing.T) {
 			t.Errorf("failed to decode request body: %v", err)
 		}
 		for k, v := range inputs {
-			if body.Inputs[k] != v {
-				t.Errorf("got %v, want %v", body.Inputs[k], v)
+			if body.Inputs[k].From != v.From {
+				t.Errorf("got %v, want %v", body.Inputs[k].From, v.From)
+			}
+			if body.Inputs[k].Subject != v.Subject {
+				t.Errorf("got %v, want %v", body.Inputs[k].Subject, v.Subject)
+			}
+			if body.Inputs[k].Body != v.Body {
+				t.Errorf("got %v, want %v", body.Inputs[k].Body, v.Body)
 			}
 		}
 		resp := PredictBatchResponse{
@@ -132,7 +150,11 @@ func TestClassifierClientPredictBatch(t *testing.T) {
 func TestClassifierClientNon200(t *testing.T) {
 	ctx := context.Background()
 	apiKey := "test"
-	input := "input"
+	input := &PredictRequest{
+		From:    "from",
+		Subject: "subject",
+		Body:    "body",
+	}
 	want := false
 	status := http.StatusBadRequest
 

--- a/cloudfunctions/email_push_notifications/sync.go
+++ b/cloudfunctions/email_push_notifications/sync.go
@@ -106,7 +106,7 @@ func syncNewEmails(
 		}
 
 		// process messages
-		examples := map[string]string{}
+		examples := map[string]*PredictRequest{}
 		for _, message := range messages {
 			// payload isn't included in the list endpoint responses
 			message, err := gmailSrv.Users.Messages.Get(gmailUser, message.Id).Do()
@@ -121,8 +121,12 @@ func syncNewEmails(
 				continue
 			}
 
-			text, err := mail.MessageToString(message)
-			examples[message.Id] = text
+			example := &PredictRequest{
+				From:    mail.MessageSender(message),
+				Subject: mail.MessageSubject(message),
+				Body:    mail.MessageBody(message),
+			}
+			examples[message.Id] = example
 		}
 
 		log.Printf("number of emails to classify: %d", len(examples))

--- a/cloudfunctions/full_email_sync/cloudfunction.go
+++ b/cloudfunctions/full_email_sync/cloudfunction.go
@@ -186,7 +186,7 @@ func fullEmailSync(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// process messages
-		examples := map[string]string{}
+		examples := map[string]*PredictRequest{}
 		for _, message := range messages {
 			// payload isn't included in the list endpoint responses
 			message, err := gmailSrv.Users.Messages.Get(gmailUser, message.Id).Do()
@@ -202,8 +202,12 @@ func fullEmailSync(w http.ResponseWriter, r *http.Request) {
 			if message.Payload == nil {
 				continue
 			}
-			text, err := mail.MessageToString(message)
-			examples[message.Id] = text
+			example := &PredictRequest{
+				From:    mail.MessageSender(message),
+				Subject: mail.MessageSubject(message),
+				Body:    mail.MessageBody(message),
+			}
+			examples[message.Id] = example
 		}
 
 		log.Printf("number of emails to classify: %d", len(examples))

--- a/libs/gmail/fwd.go
+++ b/libs/gmail/fwd.go
@@ -81,8 +81,7 @@ func (m ForwardMessage) References() string {
 func (m ForwardMessage) ParentBody() string {
 	// The "Body:" field will contain the contents of the parent's
 	// "Body:" field (if any)
-	content, _ := getContentFromMessageParts(m.Parent.Payload)
-	return content
+	return MessageBody(m.Parent)
 }
 
 // Raw returns the raw RFC-822 compliant forwarded message.

--- a/libs/gmail/go.mod
+++ b/libs/gmail/go.mod
@@ -3,7 +3,6 @@ module github.com/shared-recruiting-co/shared-recruiting-co/libs/gmail
 go 1.19
 
 require (
-	github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	google.golang.org/api v0.103.0
 )
@@ -16,9 +15,6 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
-	github.com/mattn/go-runewidth v0.0.9 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect

--- a/libs/gmail/go.sum
+++ b/libs/gmail/go.sum
@@ -47,16 +47,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.0 h1:y8Yozv7SZtlU//QXbez
 github.com/googleapis/enterprise-certificate-proxy v0.2.0/go.mod h1:8C0jb7/mgJe/9KK8Lm7X9ctZC2t60YyIpYEI16jx0Qg=
 github.com/googleapis/gax-go/v2 v2.7.0 h1:IcsPKeInNvYi7eqSaDjiZqDDKu5rsmunY0Y1YupQSSQ=
 github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57QpBWsYpwqHJx8=
-github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba h1:QFQpJdgbON7I0jr2hYW7Bs+XV0qjc3d5tZoDnRFnqTg=
-github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf h1:pvbZ0lM0XWPBqUKqFU8cmavspvIl9nulOYwdy6IFRRo=
-github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf/go.mod h1:RJID2RhlZKId02nZ62WenDCkgHFerpIOmW0iT7GKmXM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/libs/gmail/messages.go
+++ b/libs/gmail/messages.go
@@ -2,96 +2,78 @@ package gmail
 
 import (
 	"encoding/base64"
-	"fmt"
+	"strings"
 
 	"google.golang.org/api/gmail/v1"
-
-	"github.com/jaytaylor/html2text"
 )
 
-func getHTMLContentFromMessageParts(m *gmail.MessagePart) (string, error) {
+func MessageHeader(m *gmail.Message, header string) string {
+	header = strings.ToLower(header)
+	for _, h := range m.Payload.Headers {
+		if strings.ToLower(h.Name) == header {
+			return h.Value
+		}
+	}
+	return ""
+}
+
+func MessageSender(m *gmail.Message) string {
+	return MessageHeader(m, "From")
+}
+
+func MessageSubject(m *gmail.Message) string {
+	return MessageHeader(m, "Subject")
+}
+
+func MessageBody(m *gmail.Message) string {
+	// try to get native text content first
+	body := getTextContentFromMessageParts(m.Payload)
+
+	if body != "" {
+		return body
+	}
+
+	// else try get html content
+	return getHTMLContentFromMessageParts(m.Payload)
+}
+
+func getHTMLContentFromMessageParts(m *gmail.MessagePart) string {
 	if m.MimeType == "text/html" {
 		decoded, err := base64.URLEncoding.DecodeString(m.Body.Data)
-		text, err := html2text.FromString(string(decoded),
-			html2text.Options{
-				PrettyTables: false,
-				// text only loses some information about headers, lists, block quotes, bold, italic text
-				// https://github.com/jaytaylor/html2text/pull/49/files
-				TextOnly: false,
-			})
-
 		if err != nil {
-			return "", err
+			return ""
 		}
 
-		return text, nil
+		return string(decoded)
 	}
 
 	// recursively look for a html-based body
 	for _, p := range m.Parts {
-		content, mimeType := getHTMLContentFromMessageParts(p)
+		content := getHTMLContentFromMessageParts(p)
 		if content != "" {
-			return content, mimeType
+			return content
 		}
 	}
 
-	return "", nil
+	return ""
 }
 
-func getTextContentFromMessageParts(m *gmail.MessagePart) (string, error) {
+func getTextContentFromMessageParts(m *gmail.MessagePart) string {
 	if m.MimeType == "text/plain" {
 		decoded, err := base64.URLEncoding.DecodeString(m.Body.Data)
 		if err != nil {
-			return "", err
+			return ""
 		}
-		return string(decoded), nil
+		return string(decoded)
 	}
 
 	// recursively look for a text-based body
 	for _, p := range m.Parts {
-		content, _ := getTextContentFromMessageParts(p)
+		content := getTextContentFromMessageParts(p)
 		if content != "" {
-			return content, nil
+			return content
 		}
 	}
 
-	return "", nil
-}
-
-func getContentFromMessageParts(m *gmail.MessagePart) (string, error) {
-	// try to get native text content first
-	// else get html content and convert to text
-	text, err := getTextContentFromMessageParts(m)
-
-	// if there is an error or any text, return it
-	if (err != nil) || (text != "") {
-		return text, err
-	}
-
-	return getHTMLContentFromMessageParts(m)
-}
-
-func MessageToString(m *gmail.Message) (string, error) {
-	var from, subject string
-
-	// get sender and subject from headers
-	for _, h := range m.Payload.Headers {
-		if h.Name == "Subject" {
-			subject = h.Value
-		}
-		if h.Name == "From" {
-			from = h.Value
-		}
-	}
-
-	// parse body parts for body text
-	body, err := getContentFromMessageParts(m.Payload)
-
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf(` From: %s
- Subject: %s
- Body: %s`, from, subject, body), nil
+	return ""
 }


### PR DESCRIPTION
### Description
Updates the interface for the classifier to take in the email in a generic (from, subject, body) form. Pushes the reprocess to the model.

Delaying moving the classifier client/interface into `/libs` for a little longer...

### Commits
- refactor: simplify messages api
- feat: switch to new v1 model interface
