### PR TITLE
Insert Emails to Collect Rather than Fwd

### DIFF
--- a/cloudfunctions/email_push_notifications/sync.go
+++ b/cloudfunctions/email_push_notifications/sync.go
@@ -19,10 +19,6 @@ import (
 	"google.golang.org/api/idtoken"
 )
 
-const (
-	forwardTo = "Examples <examples@sharedrecruiting.co>"
-)
-
 type FullEmailSyncRequest struct {
 	Email     string    `json:"email"`
 	StartDate time.Time `json:"start_date"`
@@ -198,11 +194,17 @@ func handleRecruitingEmails(srv *mail.Service, profile client.UserProfile, jobLa
 
 	if profile.AutoContribute {
 		for _, id := range messageIDs {
-			_, err := srv.ForwardEmail(id, forwardTo)
+			// shouldn't happen
+			if examplesCollectorSrv == nil {
+				log.Print("examples collector service not initialized")
+				break
+			}
+			// clone the message to the examples inbox
+			_, err := mail.CloneMessage(srv, examplesCollectorSrv, id, collectedExampleLabels)
 
 			if err != nil {
 				// don't abort on error
-				log.Printf("error forwarding email %s: %v", id, err)
+				log.Printf("error collecting email %s: %v", id, err)
 				continue
 			}
 		}

--- a/libs/gmail/clone.go
+++ b/libs/gmail/clone.go
@@ -1,0 +1,23 @@
+package gmail
+
+import (
+	"google.golang.org/api/gmail/v1"
+)
+
+// CloneMessage is a convenience function to cloning a message from one inbox to another.
+// On success, it will return the new destination message.
+// Cloning differs from forwarding because it preserves the original message sender, recipient, and all other headers.
+func CloneMessage(src *Service, dst *Service, messageID string, dstLabelIds []string) (*gmail.Message, error) {
+	// Get the raw message from the source account
+	msg, err := src.Users.Messages.Get(src.UserID, messageID).Format("raw").Do()
+	if err != nil {
+		return nil, err
+	}
+	// Clear the source specific message properties
+	msg.Id = ""
+	msg.ThreadId = ""
+	// Set the destination labels
+	msg.LabelIds = dstLabelIds
+	// Insert the message into the destination account
+	return dst.Users.Messages.Insert(dst.UserID, msg).Do()
+}


### PR DESCRIPTION
### Description
Use Gmail's `insert` API to "clone" a message from a source inbox to a destination inbox.

This is better for collecting examples because it preserves the original message headers and format. It also doesn't create new messages in the user's inbox history, which we then later have to process. 
