### PR TITLE
fix: run auto assign in context of base fork

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -2,7 +2,7 @@ name: Auto Assign
 on:
   # issues:
     # types: [opened, edited, labeled, unlabeled]
-  pull_request:
+  pull_request_target:
     types: [opened]
     # types: [opened, edited, labeled, unlabeled]
 jobs:


### PR DESCRIPTION
### Description

Auto assign failed to run on https://github.com/shared-recruiting-co/shared-recruiting-co/pull/58 because it references `GITHUB_TOKEN`.

This runs it in the context of the base branch (`pull_request_target`), allowing it to run on PRs from forked repos.

<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [x] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
