### PR TITLE
feat: add server name for error tracking

### DIFF
--- a/cloudfunctions/email_push_notifications/cloudfunction.go
+++ b/cloudfunctions/email_push_notifications/cloudfunction.go
@@ -90,6 +90,7 @@ func emailPushNotificationHandler(ctx context.Context, e event.Event) error {
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production,
 		TracesSampleRate: 1.0,
+		ServerName:       "email-push-notifications",
 	})
 	if err != nil {
 		return fmt.Errorf("sentry.Init: %v", err)

--- a/cloudfunctions/full_email_sync/cloudfunction.go
+++ b/cloudfunctions/full_email_sync/cloudfunction.go
@@ -65,6 +65,7 @@ func fullEmailSync(w http.ResponseWriter, r *http.Request) {
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production,
 		TracesSampleRate: 1.0,
+		ServerName:       "full-email-sync",
 	})
 	if err != nil {
 		log.Printf("sentry.Init: %s", err)

--- a/cloudfunctions/watch_emails/cloudfunction.go
+++ b/cloudfunctions/watch_emails/cloudfunction.go
@@ -48,6 +48,7 @@ func runWatchEmails(w http.ResponseWriter, r *http.Request) {
 		// of transactions for performance monitoring.
 		// We recommend adjusting this value in production,
 		TracesSampleRate: 1.0,
+		ServerName:       "watch-emails",
 	})
 	if err != nil {
 		log.Printf("sentry.Init: %s", err)


### PR DESCRIPTION
### Description

Add `ServerName` to distinguish between which cloud function the error originated. 

I accidentally pushed the sentry implementation commits to main, but I'm going to deploy the changes to production before merging. Once confirmed working, I will merge this PR

Closes #51 

<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [x] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
