### PR TITLE
feat(gmail): Add Thread and Message Helpers

### DIFF
--- a/libs/gmail/gmail.go
+++ b/libs/gmail/gmail.go
@@ -373,6 +373,20 @@ func (s *Service) GetMessage(id string) (*gmail.Message, error) {
 	return ExecuteWithRetries(f)
 }
 
+// Threads
+
+// GetThread() fetches a thread by ID with messages in the given format
+// See https://developers.google.com/gmail/api/reference/rest/v1/users.threads/get#Format for format values
+//
+// It is a convenience method that wraps the gmail API call
+// It opens opportunities for caching and rate-limiting handling
+func (s *Service) GetThread(id, format string) (*gmail.Thread, error) {
+	f := func() (*gmail.Thread, error) {
+		return s.Users.Threads.Get(s.UserID, id).Format(format).Do()
+	}
+	return ExecuteWithRetries(f)
+}
+
 // Ideas for future
 // ListMessages()
 // cache GetMessage calls until next ListMessages call

--- a/libs/gmail/message.go
+++ b/libs/gmail/message.go
@@ -16,6 +16,7 @@ func SortMessagesByDate(messages []*gmail.Message) {
 	})
 }
 
+// MessageHeader returns the value of the header with the given name
 func MessageHeader(m *gmail.Message, header string) string {
 	header = strings.ToLower(header)
 	for _, h := range m.Payload.Headers {
@@ -26,14 +27,21 @@ func MessageHeader(m *gmail.Message, header string) string {
 	return ""
 }
 
+// MessageSender returns the sender of the message
+// The sender is the email address of the first "From" header
 func MessageSender(m *gmail.Message) string {
 	return MessageHeader(m, "From")
 }
 
+// MessageSubject returns the subject of the message
 func MessageSubject(m *gmail.Message) string {
 	return MessageHeader(m, "Subject")
 }
 
+// MessageBody returns the body of the message as a string
+//
+// It first checks for a text/plain body.
+// If none is found, it checks for a text/html body.
 func MessageBody(m *gmail.Message) string {
 	// try to get native text content first
 	body := getTextContentFromMessageParts(m.Payload)
@@ -85,4 +93,22 @@ func getTextContentFromMessageParts(m *gmail.MessagePart) string {
 	}
 
 	return ""
+}
+
+// MessageHasLabel returns true if the message contains the given label id
+func MessageHasLabel(m *gmail.Message, id string) bool {
+	for _, l := range m.LabelIds {
+		if l == id {
+			return true
+		}
+	}
+	return false
+}
+
+// IsMessageSent returns true if the message was sent by the current user
+//
+// There are a number of ways to check if a message was sent by a user.
+// This function checks if the message contains the system "SENT" label, which allows us to only fetch the minimal message information (no headers) from a thread.
+func IsMessageSent(m *gmail.Message) bool {
+	return MessageHasLabel(m, "SENT")
 }

--- a/libs/gmail/message.go
+++ b/libs/gmail/message.go
@@ -2,10 +2,19 @@ package gmail
 
 import (
 	"encoding/base64"
+	"sort"
 	"strings"
 
 	"google.golang.org/api/gmail/v1"
 )
+
+// SortMessagesByDate sorts messages by date received by gmail (ascending)
+// The messages are sorted in place.
+func SortMessagesByDate(messages []*gmail.Message) {
+	sort.Slice(messages, func(i, j int) bool {
+		return messages[i].InternalDate < messages[j].InternalDate
+	})
+}
 
 func MessageHeader(m *gmail.Message, header string) string {
 	header = strings.ToLower(header)

--- a/libs/gmail/message_test.go
+++ b/libs/gmail/message_test.go
@@ -1,0 +1,227 @@
+package gmail_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	mail "github.com/shared-recruiting-co/shared-recruiting-co/libs/gmail"
+	"google.golang.org/api/gmail/v1"
+)
+
+func TestSortMessagesByDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []*gmail.Message
+		want     []*gmail.Message
+	}{
+		{
+			name: "Sort",
+			messages: []*gmail.Message{
+				{
+					Id:           "2",
+					InternalDate: 2,
+				},
+				{
+					Id:           "1",
+					InternalDate: 1,
+				},
+			},
+			want: []*gmail.Message{
+				{
+					Id:           "1",
+					InternalDate: 1,
+				},
+				{
+					Id:           "2",
+					InternalDate: 2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mail.SortMessagesByDate(tc.messages)
+			for i, m := range tc.messages {
+				if m.Id != tc.want[i].Id {
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestMessageHeader(t *testing.T) {
+	message := &gmail.Message{
+		Payload: &gmail.MessagePart{
+			Headers: []*gmail.MessagePartHeader{
+				{
+					Name:  "From",
+					Value: "from",
+				},
+				{
+					Name:  "TO",
+					Value: "to",
+				},
+				{
+					Name:  "Subject",
+					Value: "subject",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "Simple",
+			header: "From",
+			want:   "from",
+		},
+		{
+			name:   "Case Insensitive",
+			header: "TO",
+			want:   "to",
+		},
+		{
+			name:   "Missing",
+			header: "Missing",
+			want:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mail.MessageHeader(message, tc.header)
+			if got != tc.want {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestMessageBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		message *gmail.Message
+		want    string
+	}{
+		{
+			name: "text/plain",
+			message: &gmail.Message{
+				Payload: &gmail.MessagePart{
+					MimeType: "text/plain",
+					Body: &gmail.MessagePartBody{
+						Data: base64.URLEncoding.EncodeToString([]byte("data")),
+					},
+				},
+			},
+			want: "data",
+		},
+		{
+			name: "text/html",
+			message: &gmail.Message{
+				Payload: &gmail.MessagePart{
+					MimeType: "text/html",
+					Body: &gmail.MessagePartBody{
+						Data: base64.URLEncoding.EncodeToString([]byte("<html>data</html>")),
+					},
+				},
+			},
+			want: "<html>data</html>",
+		},
+		{
+			name: "No Body",
+			message: &gmail.Message{
+				Payload: &gmail.MessagePart{},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mail.MessageBody(tc.message)
+			if got != tc.want {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestMessageHasLabel(t *testing.T) {
+	label := "label"
+	message := &gmail.Message{
+		LabelIds: []string{"one", label, "two"},
+	}
+	tests := []struct {
+		name  string
+		label string
+		want  bool
+	}{
+		{
+			name:  "Has Label",
+			label: label,
+			want:  true,
+		},
+		{
+			name:  "Missing Label",
+			label: "does not exist",
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mail.MessageHasLabel(message, tc.label)
+			if got != tc.want {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestIsMessageSent(t *testing.T) {
+	tests := []struct {
+		name    string
+		message *gmail.Message
+		want    bool
+	}{
+		{
+			name: "Sent",
+			message: &gmail.Message{
+				LabelIds: []string{"INBOX", "SENT", "UNREAD"},
+			},
+			want: true,
+		},
+		{
+			name: "Received",
+			message: &gmail.Message{
+				LabelIds: []string{"INBOX", "UNREAD"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mail.IsMessageSent(tc.message)
+			if got != tc.want {
+				t.Fail()
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

Relates to #50

Adds helper functions for working with threads and messages. Finally adds unit tests for `message.go`. We should consider moving messages to `/libs/gmail/message/` to avoid the redundant `MessageXXX` prefix on each function. 


### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [x] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
