### PR TITLE
Ad-hoc Cloud Function for Parsing Emails into Jobs

### DIFF
--- a/cloudfunctions/adhoc/main.go
+++ b/cloudfunctions/adhoc/main.go
@@ -1,0 +1,21 @@
+package cloudfunctions
+
+import (
+	"encoding/base64"
+	"os"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+const provider = "google"
+
+func init() {
+	functions.HTTP("PopulateJobs", populateJobs)
+}
+
+func jsonFromEnv(env string) ([]byte, error) {
+	encoded := os.Getenv(env)
+	decoded, err := base64.URLEncoding.DecodeString(encoded)
+
+	return decoded, err
+}

--- a/cloudfunctions/adhoc/migrate_labels.go
+++ b/cloudfunctions/adhoc/migrate_labels.go
@@ -1,32 +1,17 @@
 package cloudfunctions
 
 import (
-	"encoding/base64"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 
-	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"google.golang.org/api/gmail/v1"
 
 	"github.com/shared-recruiting-co/shared-recruiting-co/libs/db/client"
 	mail "github.com/shared-recruiting-co/shared-recruiting-co/libs/gmail"
 	srclabel "github.com/shared-recruiting-co/shared-recruiting-co/libs/gmail/label"
 )
-
-const provider = "google"
-
-func init() {
-	functions.HTTP("MigrateLabels", migrateLabels)
-}
-
-func jsonFromEnv(env string) ([]byte, error) {
-	encoded := os.Getenv(env)
-	decoded, err := base64.URLEncoding.DecodeString(encoded)
-
-	return decoded, err
-}
 
 func migrateLabels(w http.ResponseWriter, r *http.Request) {
 	log.Println("running labels migration")

--- a/cloudfunctions/adhoc/ml.go
+++ b/cloudfunctions/adhoc/ml.go
@@ -1,0 +1,143 @@
+package cloudfunctions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Consider moving to share library in future
+
+type EmailInput struct {
+	From    string `json:"from"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+type ClassifyRequest = EmailInput
+
+type ClassifyResponse struct {
+	Result bool `json:"result"`
+}
+
+type BatchClassifyRequest struct {
+	Inputs map[string]*ClassifyRequest `json:"inputs"`
+}
+
+type BatchClassifyResponse struct {
+	Results map[string]bool `json:"results"`
+}
+
+type ParseJobRequest = EmailInput
+
+type ParseJobResponse struct {
+	Company   string `json:"company"`
+	Title     string `json:"title"`
+	Recruiter string `json:"recruiter"`
+}
+
+type BatchParseJobRequest struct {
+	Inputs map[string]*BatchParseJobRequest `json:"inputs"`
+}
+
+type BatchParseJobResponse struct {
+	Results map[string]bool `json:"results"`
+}
+
+type MLService interface {
+	// Classify if the input is a recruiting email or not
+	Classify(input *ClassifyRequest) (*ClassifyResponse, error)
+	// Classify if the inputs recruiting emails or not
+	BatchClassify(inputs *BatchClassifyRequest) (*BatchClassifyResponse, error)
+	// Parse if the input meets the classification
+	ParseJob(input *ParseJobRequest) (*ParseJobResponse, error)
+	// Parse if the inputs are spam or not
+	BatchParseJob(req *BatchParseJobRequest) (*BatchParseJobResponse, error)
+}
+
+type MLClient struct {
+	ctx       context.Context
+	baseURL   string
+	authToken string
+}
+
+type MLClientArgs struct {
+	BaseURL   string
+	AuthToken string
+}
+
+func NewMLClient(ctx context.Context, args MLClientArgs) *MLClient {
+	return &MLClient{
+		ctx:       ctx,
+		baseURL:   args.BaseURL,
+		authToken: args.AuthToken,
+	}
+}
+
+func (c *MLClient) Classify(input *ClassifyRequest) (*ClassifyResponse, error) {
+	resp := &ClassifyResponse{}
+	err := c.doRequest("POST", "/v1/classify", input, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *MLClient) BatchClassify(inputs *BatchClassifyRequest) (*BatchClassifyResponse, error) {
+	resp := &BatchClassifyResponse{}
+	err := c.doRequest("POST", "/v1/classify/batch", inputs, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *MLClient) ParseJob(input *ParseJobRequest) (*ParseJobResponse, error) {
+	resp := &ParseJobResponse{}
+	err := c.doRequest("POST", "/v1/classify", input, resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (c *MLClient) BatchParseJob(inputs *BatchParseJobRequest) (*BatchParseJobResponse, error) {
+	resp := &BatchParseJobResponse{}
+	err := c.doRequest("POST", "/v1/classify/batch", inputs, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *MLClient) doRequest(method string, path string, req interface{}, resp interface{}) error {
+	url := c.baseURL + path
+	body, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	reqBody := bytes.NewBuffer(body)
+	httpReq, err := http.NewRequestWithContext(c.ctx, method, url, reqBody)
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.authToken != "" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	}
+	httpResp, err := http.DefaultClient.Do(httpReq)
+
+	if err != nil {
+		return err
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+	}
+
+	defer httpResp.Body.Close()
+	err = json.NewDecoder(httpResp.Body).Decode(resp)
+	return err
+}

--- a/cloudfunctions/adhoc/populate_jobs.go
+++ b/cloudfunctions/adhoc/populate_jobs.go
@@ -36,7 +36,7 @@ func handleError(w http.ResponseWriter, msg string, err error) {
 }
 
 func populateJobs(w http.ResponseWriter, r *http.Request) {
-	log.Println("running labels migration")
+	log.Println("running populate jobs")
 	ctx := r.Context()
 	creds, err := jsonFromEnv("GOOGLE_OAUTH2_CREDENTIALS")
 	if err != nil {
@@ -188,6 +188,7 @@ func populateJobs(w http.ResponseWriter, r *http.Request) {
 
 		// predict one at a time for now
 		for id, input := range inputs {
+			log.Printf("parsing email: %s", id)
 			job, err := ml.ParseJob(input)
 			// for now, abort on error
 			if err != nil {
@@ -221,7 +222,7 @@ func populateJobs(w http.ResponseWriter, r *http.Request) {
 
 			err = queries.InsertUserEmailJob(ctx, client.InsertUserEmailJobParams{
 				UserID:        user.UserID,
-				UserEmail:     user.Email,
+				UserEmail:     email,
 				EmailThreadID: message.ThreadId,
 				EmailedAt:     emailedAt,
 				Company:       job.Company,

--- a/cloudfunctions/adhoc/populate_jobs.go
+++ b/cloudfunctions/adhoc/populate_jobs.go
@@ -1,0 +1,279 @@
+package cloudfunctions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/idtoken"
+
+	"github.com/shared-recruiting-co/shared-recruiting-co/libs/db/client"
+	mail "github.com/shared-recruiting-co/shared-recruiting-co/libs/gmail"
+	srclabel "github.com/shared-recruiting-co/shared-recruiting-co/libs/gmail/label"
+)
+
+// 1. Fetch all threads with srclabel.JobsOpportunity
+// 2. Filter all messages before a reply
+// 3. Pick the earliest message
+// 4. Hit the parse endpoint
+// 5. if all fields are present, insert a job
+// 6. if any fields are missing, log
+
+type PopulateJobsRequest struct {
+	Email     string    `json:"email"`
+	StartDate time.Time `json:"start_date"`
+}
+
+func handleError(w http.ResponseWriter, msg string, err error) {
+	err = fmt.Errorf("%s: %w", msg, err)
+	log.Print(err)
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+func populateJobs(w http.ResponseWriter, r *http.Request) {
+	log.Println("running labels migration")
+	ctx := r.Context()
+	creds, err := jsonFromEnv("GOOGLE_OAUTH2_CREDENTIALS")
+	if err != nil {
+		log.Printf("error getting credentials: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Get the request body
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		handleError(w, "error reading request body", err)
+		return
+	}
+	var data PopulateJobsRequest
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		handleError(w, "error unmarshalling request body", err)
+		return
+	}
+	email := data.Email
+	startDate := data.StartDate
+
+	log.Println("populate jobs request")
+
+	// Create SRC client
+	apiURL := os.Getenv("SUPABASE_API_URL")
+	apiKey := os.Getenv("SUPABASE_API_KEY")
+	queries := client.NewHTTP(apiURL, apiKey)
+
+	// 1. Fetch valid auth tokens for all users
+	user, err := queries.GetUserProfileByEmail(ctx, email)
+	if err != nil {
+		handleError(w, "error getting user profile by email", err)
+		return
+	}
+
+	// Get User' OAuth Token
+	userToken, err := queries.GetUserOAuthToken(ctx, client.GetUserOAuthTokenParams{
+		UserID:   user.UserID,
+		Provider: provider,
+	})
+	if err != nil {
+		handleError(w, "error getting user oauth token", err)
+		return
+	}
+
+	// Create Gmail Service
+	auth := []byte(userToken.Token)
+	srv, err := mail.NewService(ctx, creds, auth)
+
+	// Create recruiting detector client
+	mlServiceBaseURL := os.Getenv("ML_SERVICE_URL")
+	idTokenSource, err := idtoken.NewTokenSource(ctx, mlServiceBaseURL)
+	if err != nil {
+		handleError(w, "error creating id token source", err)
+		return
+	}
+	idToken, err := idTokenSource.Token()
+	if err != nil {
+		handleError(w, "error getting id token", err)
+		return
+	}
+
+	ml := NewMLClient(ctx, MLClientArgs{
+		BaseURL:   mlServiceBaseURL,
+		AuthToken: idToken.AccessToken,
+	})
+
+	var threads []*gmail.Thread
+	pageToken := ""
+
+	// 1. Fetch all threads with srclabel.JobsOpportunity
+	// 2. Filter all messages before a reply
+	// 3. Pick the earliest message
+	// 4. Hit the parse endpoint
+	// 5. if all fields are present, insert a job
+	// 6. if any fields are missing, log
+
+	// batch process messages to reduce memory usage
+	for {
+		// get next set of messages
+		// if this is the first notification, trigger a one-time sync
+		threads, pageToken, err = fetchJobThreadsSinceDate(srv, startDate, pageToken)
+
+		// for now, abort on error
+		if err != nil {
+			handleError(w, "error fetching emails", err)
+			return
+		}
+
+		// get the messages for each thread
+		var messages map[string]*gmail.Message
+
+		for _, t := range threads {
+			thread, err := srv.GetThread(t.Id, "minimal")
+			if err != nil {
+				// for now abort on error
+				handleError(w, "error fetching thread", err)
+				return
+			}
+
+			// get messages before the first reply
+			filtered := filterMessagesAfterReply(thread.Messages)
+
+			if len(filtered) == 0 {
+				// no messages before the first reply
+				continue
+			}
+
+			// get the earliest message (filterMessagesAfterReply sorts by date ascending)
+			earliest := filtered[0]
+
+			// save for processing
+			messages[earliest.Id] = earliest
+		}
+
+		// process messages
+		inputs := map[string]*ParseJobRequest{}
+		for id, _ := range messages {
+			// payload isn't included in the list endpoint responses
+			message, err := srv.GetMessage(id)
+
+			// for now, abort on error
+			if err != nil {
+				handleError(w, "error getting message", err)
+				return
+			}
+
+			messages[id] = message
+
+			// filter out empty messages
+			if message.Payload == nil {
+				continue
+			}
+
+			inputs[message.Id] = &ParseJobRequest{
+				From:    mail.MessageSender(message),
+				Subject: mail.MessageSubject(message),
+				Body:    mail.MessageBody(message),
+			}
+		}
+
+		log.Printf("number of emails to parse: %d", len(inputs))
+
+		if len(inputs) == 0 {
+			break
+		}
+
+		// predict one at a time for now
+		for id, input := range inputs {
+			job, err := ml.ParseJob(input)
+			// for now, abort on error
+			if err != nil {
+				handleError(w, "error parsing job", err)
+				return
+			}
+
+			// if fields are missing, skip
+			if job.Company == "" || job.Title == "" && job.Recruiter == "" {
+				// print sender and subject
+				log.Printf("skipping job: %v", job)
+				continue
+			}
+
+			message := messages[id]
+			recruiterEmail := mail.MessageSenderEmail(message)
+			data := map[string]interface{}{
+				"recruiter":       job.Company,
+				"recruiter_email": recruiterEmail,
+			}
+
+			// turn data into json.RawMessage
+			b, err := json.Marshal(data)
+			if err != nil {
+				handleError(w, "error marshaling data", err)
+				return
+			}
+
+			// convert epoch ms to time.Time
+			emailedAt := time.Unix(message.InternalDate/1000, 0)
+
+			err = queries.InsertUserEmailJob(ctx, client.InsertUserEmailJobParams{
+				UserID:        user.UserID,
+				UserEmail:     user.Email,
+				EmailThreadID: message.ThreadId,
+				EmailedAt:     emailedAt,
+				Company:       job.Company,
+				JobTitle:      job.Title,
+				Data:          b,
+			})
+
+			// for now, abort on error
+			if err != nil {
+				handleError(w, "error inserting job", err)
+				return
+			}
+		}
+
+		if pageToken == "" {
+			break
+		}
+	}
+
+	log.Println("done.")
+}
+
+func filterMessagesAfterReply(messages []*gmail.Message) []*gmail.Message {
+	filtered := []*gmail.Message{}
+	// ensure messages are sorted by ascending date
+	mail.SortMessagesByDate(messages)
+
+	for _, m := range messages {
+		if mail.IsMessageSent(m) {
+			break
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
+
+// fetchJobThreadsSinceDate fetches all job threads since the start date
+func fetchJobThreadsSinceDate(srv *mail.Service, date time.Time, pageToken string) ([]*gmail.Thread, string, error) {
+	q := fmt.Sprintf("-label:sent label:%s after:%s", srclabel.JobsOpportunity.Name, date.Format("2006/01/02"))
+
+	r, err := mail.ExecuteWithRetries(func() (*gmail.ListThreadsResponse, error) {
+		return srv.Users.Threads.
+			List(srv.UserID).
+			PageToken(pageToken).
+			Q(q).
+			MaxResults(100).
+			Do()
+	})
+
+	if err != nil {
+		return nil, "", err
+	}
+
+	return r.Threads, r.NextPageToken, nil
+}

--- a/libs/gmail/message.go
+++ b/libs/gmail/message.go
@@ -33,6 +33,27 @@ func MessageSender(m *gmail.Message) string {
 	return MessageHeader(m, "From")
 }
 
+// MessageSenderEmail returns the email address of the sender
+// It uses MessageSender to get the sender string, and then extracts the email address from it.
+//
+// Example: "John Doe" <john.doe@example.com>" -> "john.doe@example.com"
+func MessageSenderEmail(m *gmail.Message) string {
+	sender := MessageSender(m)
+	if sender == "" {
+		return ""
+	}
+
+	start := strings.Index(sender, "<")
+	end := strings.Index(sender, ">")
+
+	// no display name, just email
+	if start == -1 || end == -1 {
+		return strings.TrimSpace(sender)
+	}
+
+	return strings.TrimSpace(sender[start+1 : end])
+}
+
 // MessageSubject returns the subject of the message
 func MessageSubject(m *gmail.Message) string {
 	return MessageHeader(m, "Subject")

--- a/libs/gmail/message_test.go
+++ b/libs/gmail/message_test.go
@@ -158,6 +158,82 @@ func TestMessageBody(t *testing.T) {
 	}
 }
 
+func TestMessageSenderEmail(t *testing.T) {
+	tests := []struct {
+		name    string
+		message *gmail.Message
+		want    string
+	}{
+		{
+			name: "Only Email",
+			message: &gmail.Message{
+				Payload: &gmail.MessagePart{
+					Headers: []*gmail.MessagePartHeader{
+						{
+							Name:  "from",
+							Value: "test@example.com",
+						},
+					},
+				},
+			},
+			want: "test@example.com",
+		},
+		{
+			name: "Display Name",
+			message: &gmail.Message{
+				Payload: &gmail.MessagePart{
+					Headers: []*gmail.MessagePartHeader{
+						{
+							Name:  "From",
+							Value: "Test Test <test@example.com>",
+						},
+					},
+				},
+			},
+			want: "test@example.com",
+		},
+		{
+			name: "Whitespace",
+			message: &gmail.Message{
+				Payload: &gmail.MessagePart{
+					Headers: []*gmail.MessagePartHeader{
+						{
+							Name:  "from",
+							Value: "Test Test < test@example.com>",
+						},
+					},
+				},
+			},
+			want: "test@example.com",
+		},
+		{
+			name: "Empty",
+			message: &gmail.Message{
+				Payload: &gmail.MessagePart{
+					Headers: []*gmail.MessagePartHeader{
+						{
+							Name:  "from",
+							Value: "",
+						},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mail.MessageSenderEmail(tc.message)
+			if got != tc.want {
+				t.Fail()
+			}
+		})
+	}
+}
+
 func TestMessageHasLabel(t *testing.T) {
 	label := "label"
 	message := &gmail.Message{


### PR DESCRIPTION
### Description

Relates to #69

Creates a manually executed cloud function for iterating through labeled emails and attempting to parse jobs from them. If the ML service is able to parse it, the job is saved for the current user in the database. 

Once this is up and running, we will "productionize" it by parsing jobs in real-time as jobs are labeled with `@SRC`.

I was tempted to, but held off refactoring the `/libs` directory. I will make a ticket to refactor into a single package with the ml client. (Follow up tickets #78 #79)

<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [x] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
