### PR TITLE
feat: require users to check terms of service before signing up

### DIFF
--- a/app/src/lib/components/ConnectGoogleAccountButton.svelte
+++ b/app/src/lib/components/ConnectGoogleAccountButton.svelte
@@ -39,7 +39,7 @@
 			// log error
 			console.log('onerror', err);
 		};
-		xhr.send(`code=${response.code}&scope=${response.scope}`);
+		xhr.send(`code=${response.code}&scope=${response.scope}&agree_tos=true`);
 	};
 
 	const connectAccount = () => {

--- a/app/src/lib/components/ConnectGoogleAccountButton.svelte
+++ b/app/src/lib/components/ConnectGoogleAccountButton.svelte
@@ -5,6 +5,7 @@
 	// props
 	export let email: string | undefined;
 	export let onConnect: () => void;
+	export let disabled = false;
 
 	let loaded = Boolean(browser && window.google);
 	let error: string;
@@ -67,8 +68,10 @@
 </script>
 
 <button
-	disabled={!loaded}
-	class="flex items-center rounded-md bg-[#1a73e8] py-0.5 pl-0.5 pr-3 text-white shadow hover:bg-[#5a94ee] disabled:cursor-wait"
+	disabled={!loaded || disabled}
+	class="flex items-center rounded-md bg-[#1a73e8] py-0.5 pl-0.5 pr-3 text-white shadow hover:bg-[#5a94ee]"
+	class:disabled:cursor-wait={!loaded}
+	class:disabled:cursor-not-allowed={disabled}
 	on:click|preventDefault={connectAccount}
 	><img src="/google.svg" alt="Google logo" class="mr-3 rounded-l-md bg-white p-2" />
 	{#if connecting}

--- a/app/src/routes/(app)/account/create/+page@.svelte
+++ b/app/src/routes/(app)/account/create/+page@.svelte
@@ -4,6 +4,8 @@
 	import { supabaseClient } from '$lib/supabase/client';
 	import ConnectGoogleAccountButton from '$lib/components/ConnectGoogleAccountButton.svelte';
 
+	let tos = false;
+
 	const onConnect = () => {
 		goto('/account/profile');
 	};
@@ -27,7 +29,9 @@
 </header>
 <div class="m-2 flex flex-row items-center justify-center sm:mx-auto sm:my-16">
 	<div class="flex max-w-xl flex-col space-y-8 rounded-md p-8">
-		<h1 class="text-center text-3xl">Welcome to the SRC {$page.data.profile.firstName}!</h1>
+		<h1 class="text-center text-3xl sm:text-4xl">
+			Welcome to the SRC {$page.data.profile.firstName}!
+		</h1>
 		<p class="mt-2">
 			We're excited to have you on board! Before we can create your account, we need to connect to
 			your Google mail account.
@@ -98,8 +102,23 @@
 			soon as they hit your inbox!
 		</p>
 		<div>
-			<p class="mb-2">Use the button below to connect your account</p>
-			<ConnectGoogleAccountButton {onConnect} email={$page.data.session?.user?.email} />
+			<!-- Agree to Terms of Service -->
+			<div class="mb-4 text-sm">
+				<input type="checkbox" bind:checked={tos} name="tos" />
+				<label for="tos" class="ml-2"
+					>I agree to the <a
+						href="/legal/terms-of-service"
+						class="underline"
+						target="_blank"
+						rel="noopener noreferrer">SRC Terms of Service</a
+					></label
+				>
+			</div>
+			<ConnectGoogleAccountButton
+				{onConnect}
+				email={$page.data.session?.user?.email}
+				disabled={!tos}
+			/>
 		</div>
 		<p class="text-sm">
 			You can read more about how we use and protect your data in our <a


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

### Description

Require a client-side check for terms of service before connecting Gmail account. Technically users are already prompted in the native Google Auth modal already, but this makes it more clear. 

In the future, we can decide to persist this database side.

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [x] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
