### PR TITLE
feat: Track Recruiter Email Sync History Independently

### DIFF
--- a/cloudfunctions/email_push_notifications/cloudfunction.go
+++ b/cloudfunctions/email_push_notifications/cloudfunction.go
@@ -15,6 +15,7 @@ import (
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/getsentry/sentry-go"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/shared-recruiting-co/shared-recruiting-co/libs/src/db"
 	srcmail "github.com/shared-recruiting-co/shared-recruiting-co/libs/src/mail/gmail"
@@ -200,6 +201,8 @@ func handler(ctx context.Context, e event.Event) error {
 		// save the current history ID
 		err = cf.queries.UpsertUserEmailSyncHistory(ctx, db.UpsertUserEmailSyncHistoryParams{
 			UserID:    cf.user.UserID,
+			InboxType: db.InboxTypeCandidate,
+			Email:     null.StringFrom(cf.payload.Email),
 			HistoryID: int64(historyID),
 			SyncedAt:  time.Now(),
 		})
@@ -216,6 +219,8 @@ func handler(ctx context.Context, e event.Event) error {
 
 	err = cf.queries.UpsertUserEmailSyncHistory(ctx, db.UpsertUserEmailSyncHistoryParams{
 		UserID:    cf.user.UserID,
+		InboxType: db.InboxTypeCandidate,
+		Email:     null.StringFrom(cf.payload.Email),
 		HistoryID: int64(historyID),
 		SyncedAt:  time.Now(),
 	})
@@ -227,6 +232,8 @@ func handler(ctx context.Context, e event.Event) error {
 	revertSyncHistory := func() {
 		err := cf.queries.UpsertUserEmailSyncHistory(ctx, db.UpsertUserEmailSyncHistoryParams{
 			UserID:    cf.user.UserID,
+			InboxType: db.InboxTypeCandidate,
+			Email:     null.StringFrom(cf.payload.Email),
 			HistoryID: prevSyncHistory.HistoryID,
 			SyncedAt:  prevSyncHistory.SyncedAt,
 		})

--- a/libs/src/db/query.sql
+++ b/libs/src/db/query.sql
@@ -65,6 +65,8 @@ do update set
 -- name: GetUserEmailSyncHistory :one
 select
     user_id,
+    inbox_type,
+    email,
     history_id,
     synced_at,
     created_at,
@@ -73,11 +75,13 @@ from public.user_email_sync_history
 where user_id = $1;
 
 -- name: UpsertUserEmailSyncHistory :exec
-insert into public.user_email_sync_history(user_id, history_id, synced_at)
-values ($1, $2, $3)
+insert into public.user_email_sync_history(user_id, inbox_type, email, history_id, synced_at)
+values ($1, $2, $3, $4, $5)
 on conflict (user_id)
 do update set
     history_id = excluded.history_id,
+    inbox_type = excluded.inbox_type,
+    email = excluded.email,
     synced_at = excluded.synced_at;
 
 -- name: IncrementUserEmailStat :exec

--- a/libs/src/db/schema.sql
+++ b/libs/src/db/schema.sql
@@ -48,9 +48,13 @@ create policy "Users can update own oauth tokens."
   on public.user_oauth_token for update
   using ( auth.uid() = user_id );
 
+CREATE TYPE inbox_type AS ENUM ('candidate', 'recruiter');
+
 -- User Email Sync History Table
 create table public.user_email_sync_history (
     user_id uuid references auth.users(id) on delete cascade not null,
+    inbox_type inbox_type not null default 'candidate',
+    email text,
     history_id int8 not null,
     -- track successful sync attempts
     synced_at timestamp with time zone not null default now(),

--- a/libs/src/go.mod
+++ b/libs/src/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/api v0.107.0
+	gopkg.in/guregu/null.v4 v4.0.0
 )
 
 require (

--- a/libs/src/go.sum
+++ b/libs/src/go.sum
@@ -137,6 +137,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/guregu/null.v4 v4.0.0 h1:1Wm3S1WEA2I26Kq+6vcW+w0gcDo44YKYD7YIEJNHDjg=
+gopkg.in/guregu/null.v4 v4.0.0/go.mod h1:YoQhUrADuG3i9WqesrCmpNRwm1ypAgSHYqoOcTu/JrI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/web/src/lib/supabase/types.ts
+++ b/web/src/lib/supabase/types.ts
@@ -1,56 +1,78 @@
 export type Json = string | number | boolean | null | { [key: string]: Json } | Json[];
 
 export interface Database {
+	graphql_public: {
+		Tables: {
+			[_ in never]: never;
+		};
+		Views: {
+			[_ in never]: never;
+		};
+		Functions: {
+			graphql: {
+				Args: {
+					operationName: string;
+					query: string;
+					variables: Json;
+					extensions: Json;
+				};
+				Returns: Json;
+			};
+		};
+		Enums: {
+			[_ in never]: never;
+		};
+	};
 	public: {
 		Tables: {
 			company: {
 				Row: {
-					company_id: string;
 					company_name: string;
 					website: string;
+					company_id: string;
 					created_at: string;
 					updated_at: string;
 				};
 				Insert: {
-					company_id?: string;
 					company_name: string;
 					website: string;
+					company_id?: string;
 					created_at?: string;
 					updated_at?: string;
 				};
 				Update: {
-					company_id?: string;
 					company_name?: string;
 					website?: string;
+					company_id?: string;
 					created_at?: string;
 					updated_at?: string;
 				};
 			};
 			job: {
 				Row: {
-					job_id: string;
 					title: string;
 					description_url: string;
 					recruiter_id: string;
 					company_id: string;
+					job_id: string;
 					created_at: string;
 					updated_at: string;
 				};
 				Insert: {
-					job_id?: string;
 					title: string;
 					description_url: string;
 					recruiter_id: string;
 					company_id: string;
+					job_id?: string;
 					created_at?: string;
 					updated_at?: string;
 				};
 				Update: {
-					job_id?: string;
 					title?: string;
 					description_url?: string;
 					recruiter_id?: string;
 					company_id?: string;
+					job_id?: string;
 					created_at?: string;
 					updated_at?: string;
 				};
@@ -61,8 +83,8 @@ export interface Database {
 					email: string;
 					first_name: string;
 					last_name: string;
-					responses: Json;
 					company_id: string;
+					responses: Json;
 					created_at: string;
 					updated_at: string;
 				};
@@ -71,8 +93,8 @@ export interface Database {
 					email: string;
 					first_name: string;
 					last_name: string;
-					responses?: Json;
 					company_id: string;
+					responses?: Json;
 					created_at?: string;
 					updated_at?: string;
 				};
@@ -81,45 +103,45 @@ export interface Database {
 					email?: string;
 					first_name?: string;
 					last_name?: string;
-					responses?: Json;
 					company_id?: string;
+					responses?: Json;
 					created_at?: string;
 					updated_at?: string;
 				};
 			};
 			user_email_job: {
 				Row: {
-					job_id: string;
 					user_id: string;
 					user_email: string;
 					email_thread_id: string;
 					emailed_at: string;
 					company: string;
 					job_title: string;
+					job_id: string;
 					data: Json;
 					created_at: string;
 					updated_at: string;
 				};
 				Insert: {
-					job_id?: string;
 					user_id: string;
 					user_email: string;
 					email_thread_id: string;
 					emailed_at: string;
 					company: string;
 					job_title: string;
+					job_id?: string;
 					data?: Json;
 					created_at?: string;
 					updated_at?: string;
 				};
 				Update: {
-					job_id?: string;
 					user_id?: string;
 					user_email?: string;
 					email_thread_id?: string;
 					emailed_at?: string;
 					company?: string;
 					job_title?: string;
+					job_id?: string;
 					data?: Json;
 					created_at?: string;
 					updated_at?: string;
@@ -153,6 +175,8 @@ export interface Database {
 			};
 			user_email_sync_history: {
 				Row: {
+					email: string | null;
+					inbox_type: Database['public']['Enums']['inbox_type'];
 					user_id: string;
 					history_id: number;
 					created_at: string;
@@ -160,6 +184,8 @@ export interface Database {
 					synced_at: string;
 				};
 				Insert: {
+					email?: string | null;
+					inbox_type?: Database['public']['Enums']['inbox_type'];
 					user_id: string;
 					history_id: number;
 					created_at?: string;
@@ -167,6 +193,8 @@ export interface Database {
 					synced_at?: string;
 				};
 				Update: {
+					email?: string | null;
+					inbox_type?: Database['public']['Enums']['inbox_type'];
 					user_id?: string;
 					history_id?: number;
 					created_at?: string;
@@ -178,25 +206,25 @@ export interface Database {
 				Row: {
 					user_id: string;
 					provider: string;
-					token: Json;
 					created_at: string;
 					updated_at: string;
+					token: Json;
 					is_valid: boolean;
 				};
 				Insert: {
 					user_id: string;
 					provider: string;
-					token: Json;
 					created_at?: string;
 					updated_at?: string;
+					token: Json;
 					is_valid?: boolean;
 				};
 				Update: {
 					user_id?: string;
 					provider?: string;
-					token?: Json;
 					created_at?: string;
 					updated_at?: string;
+					token?: Json;
 					is_valid?: boolean;
 				};
 			};
@@ -206,8 +234,8 @@ export interface Database {
 					email: string;
 					first_name: string;
 					last_name: string;
-					created_at: string;
 					updated_at: string;
+					created_at: string;
 					auto_archive: boolean;
 					auto_contribute: boolean;
 					is_active: boolean;
@@ -217,8 +245,8 @@ export interface Database {
 					email: string;
 					first_name: string;
 					last_name: string;
-					created_at?: string;
 					updated_at?: string;
+					created_at?: string;
 					auto_archive?: boolean;
 					auto_contribute?: boolean;
 					is_active?: boolean;
@@ -228,8 +256,8 @@ export interface Database {
 					email?: string;
 					first_name?: string;
 					last_name?: string;
-					created_at?: string;
 					updated_at?: string;
+					created_at?: string;
 					auto_archive?: boolean;
 					auto_contribute?: boolean;
 					is_active?: boolean;
@@ -272,7 +300,26 @@ export interface Database {
 			};
 		};
 		Views: {
-			[_ in never]: never;
+			candidate_oauth_token: {
+				Row: {
+					user_id: string | null;
+					provider: string | null;
+					token: Json | null;
+					created_at: string | null;
+					updated_at: string | null;
+					is_valid: boolean | null;
+				};
+			};
+			recruiter_oauth_token: {
+				Row: {
+					user_id: string | null;
+					provider: string | null;
+					token: Json | null;
+					created_at: string | null;
+					updated_at: string | null;
+					is_valid: boolean | null;
+				};
+			};
 		};
 		Functions: {
 			increment_user_email_stat: {
@@ -283,6 +330,135 @@ export interface Database {
 					stat_value: number;
 				};
 				Returns: undefined;
+			};
+		};
+		Enums: {
+			inbox_type: 'candidate' | 'recruiter';
+		};
+	};
+	storage: {
+		Tables: {
+			buckets: {
+				Row: {
+					id: string;
+					name: string;
+					owner: string | null;
+					created_at: string | null;
+					updated_at: string | null;
+					public: boolean | null;
+				};
+				Insert: {
+					id: string;
+					name: string;
+					owner?: string | null;
+					created_at?: string | null;
+					updated_at?: string | null;
+					public?: boolean | null;
+				};
+				Update: {
+					id?: string;
+					name?: string;
+					owner?: string | null;
+					created_at?: string | null;
+					updated_at?: string | null;
+					public?: boolean | null;
+				};
+			};
+			migrations: {
+				Row: {
+					id: number;
+					name: string;
+					hash: string;
+					executed_at: string | null;
+				};
+				Insert: {
+					id: number;
+					name: string;
+					hash: string;
+					executed_at?: string | null;
+				};
+				Update: {
+					id?: number;
+					name?: string;
+					hash?: string;
+					executed_at?: string | null;
+				};
+			};
+			objects: {
+				Row: {
+					bucket_id: string | null;
+					name: string | null;
+					owner: string | null;
+					metadata: Json | null;
+					id: string;
+					created_at: string | null;
+					updated_at: string | null;
+					last_accessed_at: string | null;
+					path_tokens: string[] | null;
+				};
+				Insert: {
+					bucket_id?: string | null;
+					name?: string | null;
+					owner?: string | null;
+					metadata?: Json | null;
+					id?: string;
+					created_at?: string | null;
+					updated_at?: string | null;
+					last_accessed_at?: string | null;
+					path_tokens?: string[] | null;
+				};
+				Update: {
+					bucket_id?: string | null;
+					name?: string | null;
+					owner?: string | null;
+					metadata?: Json | null;
+					id?: string;
+					created_at?: string | null;
+					updated_at?: string | null;
+					last_accessed_at?: string | null;
+					path_tokens?: string[] | null;
+				};
+			};
+		};
+		Views: {
+			[_ in never]: never;
+		};
+		Functions: {
+			extension: {
+				Args: { name: string };
+				Returns: string;
+			};
+			filename: {
+				Args: { name: string };
+				Returns: string;
+			};
+			foldername: {
+				Args: { name: string };
+				Returns: string[];
+			};
+			get_size_by_bucket: {
+				Args: Record<PropertyKey, never>;
+				Returns: { size: number; bucket_id: string }[];
+			};
+			search: {
+				Args: {
+					prefix: string;
+					bucketname: string;
+					limits: number;
+					levels: number;
+					offsets: number;
+					search: string;
+					sortcolumn: string;
+					sortorder: string;
+				};
+				Returns: {
+					name: string;
+					id: string;
+					updated_at: string;
+					created_at: string;
+					last_accessed_at: string;
+					metadata: Json;
+				}[];
 			};
 		};
 		Enums: {

--- a/web/supabase/migrations/20230216145636_multi_inbox_type_user_email_sync.sql
+++ b/web/supabase/migrations/20230216145636_multi_inbox_type_user_email_sync.sql
@@ -1,0 +1,7 @@
+ALTER TABLE IF EXISTS user_email_sync_history 
+    ADD COLUMN email text;
+
+CREATE TYPE inbox_type AS ENUM ('candidate', 'recruiter');
+
+ALTER TABLE IF EXISTS user_email_sync_history 
+    ADD COLUMN inbox_type inbox_type NOT NULL DEFAULT 'candidate';


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->
Relates to #111
Relates to #49

### Description

In theory, a user can be a recruiter and a candidate. This allows the same email to be tracked in `user_email_sync_history` but we can progress the sync history independently.

Adding `email` to the table is a step towards supporting #49

This is the first of several migration PRs. Once `email` is lazily initialized, we will make it `not null` and update the table primary key to `(user_id, email, inbox_type)`


### Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
