### PR TITLE
Update User Email Sync History PK

### DIFF
--- a/libs/src/db/http.go
+++ b/libs/src/db/http.go
@@ -111,9 +111,9 @@ func (q *HTTPQueries) GetUserProfileByEmail(ctx context.Context, email string) (
 }
 
 // GetUserEmailSyncHistory fetches a user's email sync history.
-func (q *HTTPQueries) GetUserEmailSyncHistory(ctx context.Context, userID uuid.UUID) (UserEmailSyncHistory, error) {
+func (q *HTTPQueries) GetUserEmailSyncHistory(ctx context.Context, arg GetUserEmailSyncHistoryParams) (UserEmailSyncHistory, error) {
 	basePath := "/user_email_sync_history"
-	query := fmt.Sprintf("select=*&user_id=eq.%s", userID)
+	query := fmt.Sprintf("select=*&user_id=eq.%s&inbox_type=eq.%s&email=eq.%s", arg.UserID, arg.InboxType, arg.Email)
 	path := fmt.Sprintf("%s?%s", basePath, query)
 	var result UserEmailSyncHistory
 

--- a/libs/src/db/models.go
+++ b/libs/src/db/models.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	null "gopkg.in/guregu/null.v4"
 )
 
 type InboxType string
@@ -131,13 +130,13 @@ type UserEmailStat struct {
 }
 
 type UserEmailSyncHistory struct {
-	UserID    uuid.UUID   `json:"user_id"`
-	InboxType InboxType   `json:"inbox_type"`
-	Email     null.String `json:"email"`
-	HistoryID int64       `json:"history_id"`
-	SyncedAt  time.Time   `json:"synced_at"`
-	CreatedAt time.Time   `json:"created_at"`
-	UpdatedAt time.Time   `json:"updated_at"`
+	UserID    uuid.UUID `json:"user_id"`
+	InboxType InboxType `json:"inbox_type"`
+	Email     string    `json:"email"`
+	HistoryID int64     `json:"history_id"`
+	SyncedAt  time.Time `json:"synced_at"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type UserOauthToken struct {

--- a/libs/src/db/querier.go
+++ b/libs/src/db/querier.go
@@ -14,7 +14,7 @@ type Querier interface {
 	CountUserEmailJobs(ctx context.Context, userID uuid.UUID) (int64, error)
 	GetRecruiterByEmail(ctx context.Context, email string) (GetRecruiterByEmailRow, error)
 	GetUserEmailJob(ctx context.Context, jobID uuid.UUID) (UserEmailJob, error)
-	GetUserEmailSyncHistory(ctx context.Context, userID uuid.UUID) (UserEmailSyncHistory, error)
+	GetUserEmailSyncHistory(ctx context.Context, arg GetUserEmailSyncHistoryParams) (UserEmailSyncHistory, error)
 	GetUserOAuthToken(ctx context.Context, arg GetUserOAuthTokenParams) (UserOauthToken, error)
 	GetUserProfileByEmail(ctx context.Context, email string) (UserProfile, error)
 	IncrementUserEmailStat(ctx context.Context, arg IncrementUserEmailStatParams) error

--- a/libs/src/db/query.sql
+++ b/libs/src/db/query.sql
@@ -72,16 +72,14 @@ select
     created_at,
     updated_at
 from public.user_email_sync_history
-where user_id = $1;
+where user_id = $1 and inbox_type = $2 and email = $3;
 
 -- name: UpsertUserEmailSyncHistory :exec
 insert into public.user_email_sync_history(user_id, inbox_type, email, history_id, synced_at)
 values ($1, $2, $3, $4, $5)
-on conflict (user_id)
+on conflict (user_id, inbox_type, email)
 do update set
     history_id = excluded.history_id,
-    inbox_type = excluded.inbox_type,
-    email = excluded.email,
     synced_at = excluded.synced_at;
 
 -- name: IncrementUserEmailStat :exec

--- a/libs/src/db/schema.sql
+++ b/libs/src/db/schema.sql
@@ -48,20 +48,20 @@ create policy "Users can update own oauth tokens."
   on public.user_oauth_token for update
   using ( auth.uid() = user_id );
 
-CREATE TYPE inbox_type AS ENUM ('candidate', 'recruiter');
+create type inbox_type as enum ('candidate', 'recruiter');
 
 -- User Email Sync History Table
 create table public.user_email_sync_history (
     user_id uuid references auth.users(id) on delete cascade not null,
-    inbox_type inbox_type not null default 'candidate',
-    email text,
+    inbox_type inbox_type not null,
+    email text not null,
     history_id int8 not null,
     -- track successful sync attempts
     synced_at timestamp with time zone not null default now(),
     created_at timestamp with time zone not null default now(),
     updated_at timestamp with time zone not null default now(),
 
-    primary key (user_id)
+    primary key (user_id, inbox_type, email)
 );
 
 create trigger handle_updated_at_user_email_sync_history before update on public.user_email_sync_history

--- a/libs/src/go.mod
+++ b/libs/src/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/api v0.107.0
-	gopkg.in/guregu/null.v4 v4.0.0
 )
 
 require (

--- a/libs/src/go.sum
+++ b/libs/src/go.sum
@@ -137,8 +137,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/guregu/null.v4 v4.0.0 h1:1Wm3S1WEA2I26Kq+6vcW+w0gcDo44YKYD7YIEJNHDjg=
-gopkg.in/guregu/null.v4 v4.0.0/go.mod h1:YoQhUrADuG3i9WqesrCmpNRwm1ypAgSHYqoOcTu/JrI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/web/src/lib/supabase/types.ts
+++ b/web/src/lib/supabase/types.ts
@@ -11,10 +11,10 @@ export interface Database {
 		Functions: {
 			graphql: {
 				Args: {
-					operationName: string;
-					query: string;
-					variables: Json;
-					extensions: Json;
+					operationName?: string;
+					query?: string;
+					variables?: Json;
+					extensions?: Json;
 				};
 				Returns: Json;
 			};
@@ -22,302 +22,305 @@ export interface Database {
 		Enums: {
 			[_ in never]: never;
 		};
+		CompositeTypes: {
+			[_ in never]: never;
+		};
 	};
 	public: {
 		Tables: {
 			company: {
 				Row: {
-					company_name: string;
-					website: string;
 					company_id: string;
+					company_name: string;
 					created_at: string;
 					updated_at: string;
+					website: string;
 				};
 				Insert: {
-					company_name: string;
-					website: string;
 					company_id?: string;
+					company_name: string;
 					created_at?: string;
 					updated_at?: string;
+					website: string;
 				};
 				Update: {
-					company_name?: string;
-					website?: string;
 					company_id?: string;
+					company_name?: string;
 					created_at?: string;
 					updated_at?: string;
+					website?: string;
 				};
 			};
 			job: {
 				Row: {
-					title: string;
-					description_url: string;
-					recruiter_id: string;
 					company_id: string;
-					job_id: string;
 					created_at: string;
+					description_url: string;
+					job_id: string;
+					recruiter_id: string;
+					title: string;
 					updated_at: string;
 				};
 				Insert: {
-					title: string;
-					description_url: string;
-					recruiter_id: string;
 					company_id: string;
-					job_id?: string;
 					created_at?: string;
+					description_url: string;
+					job_id?: string;
+					recruiter_id: string;
+					title: string;
 					updated_at?: string;
 				};
 				Update: {
-					title?: string;
-					description_url?: string;
-					recruiter_id?: string;
 					company_id?: string;
-					job_id?: string;
 					created_at?: string;
+					description_url?: string;
+					job_id?: string;
+					recruiter_id?: string;
+					title?: string;
 					updated_at?: string;
 				};
 			};
 			recruiter: {
 				Row: {
-					user_id: string;
+					company_id: string;
+					created_at: string;
 					email: string;
 					first_name: string;
 					last_name: string;
-					company_id: string;
 					responses: Json;
-					created_at: string;
 					updated_at: string;
+					user_id: string;
 				};
 				Insert: {
-					user_id: string;
+					company_id: string;
+					created_at?: string;
 					email: string;
 					first_name: string;
 					last_name: string;
-					company_id: string;
 					responses?: Json;
-					created_at?: string;
 					updated_at?: string;
+					user_id: string;
 				};
 				Update: {
-					user_id?: string;
+					company_id?: string;
+					created_at?: string;
 					email?: string;
 					first_name?: string;
 					last_name?: string;
-					company_id?: string;
 					responses?: Json;
-					created_at?: string;
 					updated_at?: string;
+					user_id?: string;
 				};
 			};
 			user_email_job: {
 				Row: {
-					user_id: string;
-					user_email: string;
+					company: string;
+					created_at: string;
+					data: Json;
 					email_thread_id: string;
 					emailed_at: string;
-					company: string;
-					job_title: string;
 					job_id: string;
-					data: Json;
-					created_at: string;
+					job_title: string;
 					updated_at: string;
+					user_email: string;
+					user_id: string;
 				};
 				Insert: {
-					user_id: string;
-					user_email: string;
+					company: string;
+					created_at?: string;
+					data?: Json;
 					email_thread_id: string;
 					emailed_at: string;
-					company: string;
-					job_title: string;
 					job_id?: string;
-					data?: Json;
-					created_at?: string;
+					job_title: string;
 					updated_at?: string;
+					user_email: string;
+					user_id: string;
 				};
 				Update: {
-					user_id?: string;
-					user_email?: string;
+					company?: string;
+					created_at?: string;
+					data?: Json;
 					email_thread_id?: string;
 					emailed_at?: string;
-					company?: string;
-					job_title?: string;
 					job_id?: string;
-					data?: Json;
-					created_at?: string;
+					job_title?: string;
 					updated_at?: string;
+					user_email?: string;
+					user_id?: string;
 				};
 			};
 			user_email_stat: {
 				Row: {
-					user_id: string;
+					created_at: string;
 					email: string;
 					stat_id: string;
 					stat_value: number;
-					created_at: string;
 					updated_at: string;
+					user_id: string;
 				};
 				Insert: {
-					user_id: string;
+					created_at?: string;
 					email: string;
 					stat_id: string;
 					stat_value?: number;
-					created_at?: string;
 					updated_at?: string;
+					user_id: string;
 				};
 				Update: {
-					user_id?: string;
+					created_at?: string;
 					email?: string;
 					stat_id?: string;
 					stat_value?: number;
-					created_at?: string;
 					updated_at?: string;
+					user_id?: string;
 				};
 			};
 			user_email_sync_history: {
 				Row: {
-					email: string | null;
-					inbox_type: Database['public']['Enums']['inbox_type'];
-					user_id: string;
-					history_id: number;
 					created_at: string;
-					updated_at: string;
+					email: string;
+					history_id: number;
+					inbox_type: Database['public']['Enums']['inbox_type'];
 					synced_at: string;
+					updated_at: string;
+					user_id: string;
 				};
 				Insert: {
-					email?: string | null;
-					inbox_type?: Database['public']['Enums']['inbox_type'];
-					user_id: string;
-					history_id: number;
 					created_at?: string;
-					updated_at?: string;
+					email: string;
+					history_id: number;
+					inbox_type: Database['public']['Enums']['inbox_type'];
 					synced_at?: string;
+					updated_at?: string;
+					user_id: string;
 				};
 				Update: {
-					email?: string | null;
-					inbox_type?: Database['public']['Enums']['inbox_type'];
-					user_id?: string;
-					history_id?: number;
 					created_at?: string;
-					updated_at?: string;
+					email?: string;
+					history_id?: number;
+					inbox_type?: Database['public']['Enums']['inbox_type'];
 					synced_at?: string;
+					updated_at?: string;
+					user_id?: string;
 				};
 			};
 			user_oauth_token: {
 				Row: {
-					user_id: string;
-					provider: string;
 					created_at: string;
-					updated_at: string;
-					token: Json;
 					is_valid: boolean;
+					provider: string;
+					token: Json;
+					updated_at: string;
+					user_id: string;
 				};
 				Insert: {
-					user_id: string;
-					provider: string;
 					created_at?: string;
-					updated_at?: string;
-					token: Json;
 					is_valid?: boolean;
+					provider: string;
+					token: Json;
+					updated_at?: string;
+					user_id: string;
 				};
 				Update: {
-					user_id?: string;
-					provider?: string;
 					created_at?: string;
-					updated_at?: string;
-					token?: Json;
 					is_valid?: boolean;
+					provider?: string;
+					token?: Json;
+					updated_at?: string;
+					user_id?: string;
 				};
 			};
 			user_profile: {
 				Row: {
-					user_id: string;
-					email: string;
-					first_name: string;
-					last_name: string;
-					updated_at: string;
-					created_at: string;
 					auto_archive: boolean;
 					auto_contribute: boolean;
-					is_active: boolean;
-				};
-				Insert: {
-					user_id: string;
+					created_at: string;
 					email: string;
 					first_name: string;
+					is_active: boolean;
+					last_name: string;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					auto_archive?: boolean;
+					auto_contribute?: boolean;
+					created_at?: string;
+					email: string;
+					first_name: string;
+					is_active?: boolean;
 					last_name: string;
 					updated_at?: string;
-					created_at?: string;
-					auto_archive?: boolean;
-					auto_contribute?: boolean;
-					is_active?: boolean;
+					user_id: string;
 				};
 				Update: {
-					user_id?: string;
-					email?: string;
-					first_name?: string;
-					last_name?: string;
-					updated_at?: string;
-					created_at?: string;
 					auto_archive?: boolean;
 					auto_contribute?: boolean;
+					created_at?: string;
+					email?: string;
+					first_name?: string;
 					is_active?: boolean;
+					last_name?: string;
+					updated_at?: string;
+					user_id?: string;
 				};
 			};
 			waitlist: {
 				Row: {
-					user_id: string;
+					can_create_account: boolean;
+					created_at: string;
 					email: string;
 					first_name: string;
 					last_name: string;
 					linkedin_url: string;
 					responses: Json;
-					can_create_account: boolean;
-					created_at: string;
 					updated_at: string;
+					user_id: string;
 				};
 				Insert: {
-					user_id: string;
+					can_create_account?: boolean;
+					created_at?: string;
 					email: string;
 					first_name: string;
 					last_name: string;
 					linkedin_url: string;
 					responses?: Json;
-					can_create_account?: boolean;
-					created_at?: string;
 					updated_at?: string;
+					user_id: string;
 				};
 				Update: {
-					user_id?: string;
+					can_create_account?: boolean;
+					created_at?: string;
 					email?: string;
 					first_name?: string;
 					last_name?: string;
 					linkedin_url?: string;
 					responses?: Json;
-					can_create_account?: boolean;
-					created_at?: string;
 					updated_at?: string;
+					user_id?: string;
 				};
 			};
 		};
 		Views: {
 			candidate_oauth_token: {
 				Row: {
-					user_id: string | null;
+					created_at: string | null;
+					is_valid: boolean | null;
 					provider: string | null;
 					token: Json | null;
-					created_at: string | null;
 					updated_at: string | null;
-					is_valid: boolean | null;
+					user_id: string | null;
 				};
 			};
 			recruiter_oauth_token: {
 				Row: {
-					user_id: string | null;
+					created_at: string | null;
+					is_valid: boolean | null;
 					provider: string | null;
 					token: Json | null;
-					created_at: string | null;
 					updated_at: string | null;
-					is_valid: boolean | null;
+					user_id: string | null;
 				};
 			};
 		};
@@ -335,88 +338,91 @@ export interface Database {
 		Enums: {
 			inbox_type: 'candidate' | 'recruiter';
 		};
+		CompositeTypes: {
+			[_ in never]: never;
+		};
 	};
 	storage: {
 		Tables: {
 			buckets: {
 				Row: {
+					created_at: string | null;
 					id: string;
 					name: string;
 					owner: string | null;
-					created_at: string | null;
-					updated_at: string | null;
 					public: boolean | null;
+					updated_at: string | null;
 				};
 				Insert: {
+					created_at?: string | null;
 					id: string;
 					name: string;
 					owner?: string | null;
-					created_at?: string | null;
-					updated_at?: string | null;
 					public?: boolean | null;
+					updated_at?: string | null;
 				};
 				Update: {
+					created_at?: string | null;
 					id?: string;
 					name?: string;
 					owner?: string | null;
-					created_at?: string | null;
-					updated_at?: string | null;
 					public?: boolean | null;
+					updated_at?: string | null;
 				};
 			};
 			migrations: {
 				Row: {
+					executed_at: string | null;
+					hash: string;
 					id: number;
 					name: string;
-					hash: string;
-					executed_at: string | null;
 				};
 				Insert: {
+					executed_at?: string | null;
+					hash: string;
 					id: number;
 					name: string;
-					hash: string;
-					executed_at?: string | null;
 				};
 				Update: {
+					executed_at?: string | null;
+					hash?: string;
 					id?: number;
 					name?: string;
-					hash?: string;
-					executed_at?: string | null;
 				};
 			};
 			objects: {
 				Row: {
 					bucket_id: string | null;
+					created_at: string | null;
+					id: string;
+					last_accessed_at: string | null;
+					metadata: Json | null;
 					name: string | null;
 					owner: string | null;
-					metadata: Json | null;
-					id: string;
-					created_at: string | null;
-					updated_at: string | null;
-					last_accessed_at: string | null;
 					path_tokens: string[] | null;
+					updated_at: string | null;
 				};
 				Insert: {
 					bucket_id?: string | null;
+					created_at?: string | null;
+					id?: string;
+					last_accessed_at?: string | null;
+					metadata?: Json | null;
 					name?: string | null;
 					owner?: string | null;
-					metadata?: Json | null;
-					id?: string;
-					created_at?: string | null;
-					updated_at?: string | null;
-					last_accessed_at?: string | null;
 					path_tokens?: string[] | null;
+					updated_at?: string | null;
 				};
 				Update: {
 					bucket_id?: string | null;
+					created_at?: string | null;
+					id?: string;
+					last_accessed_at?: string | null;
+					metadata?: Json | null;
 					name?: string | null;
 					owner?: string | null;
-					metadata?: Json | null;
-					id?: string;
-					created_at?: string | null;
-					updated_at?: string | null;
-					last_accessed_at?: string | null;
 					path_tokens?: string[] | null;
+					updated_at?: string | null;
 				};
 			};
 		};
@@ -425,31 +431,40 @@ export interface Database {
 		};
 		Functions: {
 			extension: {
-				Args: { name: string };
+				Args: {
+					name: string;
+				};
 				Returns: string;
 			};
 			filename: {
-				Args: { name: string };
+				Args: {
+					name: string;
+				};
 				Returns: string;
 			};
 			foldername: {
-				Args: { name: string };
+				Args: {
+					name: string;
+				};
 				Returns: string[];
 			};
 			get_size_by_bucket: {
 				Args: Record<PropertyKey, never>;
-				Returns: { size: number; bucket_id: string }[];
+				Returns: {
+					size: number;
+					bucket_id: string;
+				}[];
 			};
 			search: {
 				Args: {
 					prefix: string;
 					bucketname: string;
-					limits: number;
-					levels: number;
-					offsets: number;
-					search: string;
-					sortcolumn: string;
-					sortorder: string;
+					limits?: number;
+					levels?: number;
+					offsets?: number;
+					search?: string;
+					sortcolumn?: string;
+					sortorder?: string;
 				};
 				Returns: {
 					name: string;
@@ -462,6 +477,9 @@ export interface Database {
 			};
 		};
 		Enums: {
+			[_ in never]: never;
+		};
+		CompositeTypes: {
 			[_ in never]: never;
 		};
 	};

--- a/web/supabase/migrations/20230218000412_multi_inbox_user_email_sync_pk.sql
+++ b/web/supabase/migrations/20230218000412_multi_inbox_user_email_sync_pk.sql
@@ -1,0 +1,11 @@
+alter table "public"."user_email_sync_history" drop constraint "user_email_sync_history_pkey";
+
+drop index if exists "public"."user_email_sync_history_pkey";
+
+alter table "public"."user_email_sync_history" alter column "email" set not null;
+
+alter table "public"."user_email_sync_history" alter column "inbox_type" drop default;
+
+create unique index user_email_sync_history_pkey on public.user_email_sync_history using btree (user_id, inbox_type, email);
+
+alter table "public"."user_email_sync_history" add constraint "user_email_sync_history_pkey" primary key using index "user_email_sync_history_pkey";


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->
Relates to #49

### Description

Updates the primary key to be `(user_id, inbox_type, email)`. This will let us track recruiter email sync history on the same table and supports multiple emails per inbox. 

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
