### PR TITLE
Deploy Separate Gmail Push Notification Handlers

### DIFF
--- a/deploy/.golangci.yml
+++ b/deploy/.golangci.yml
@@ -1,0 +1,7 @@
+issues:
+  # List of regexps of issue texts to exclude, empty list by default.
+  # But independently from this option we use default exclude patterns,
+  # it can be disabled by `exclude-use-default: false`. To list all
+  # excluded by default patterns execute `golangci-lint run --help`
+  exclude:
+    - loop variable tc captured by func literal

--- a/deploy/cloudfunction.go
+++ b/deploy/cloudfunction.go
@@ -437,7 +437,7 @@ func (i *Infra) candidateGmailPushNotifications(fullSync *CloudFunction) (*Cloud
 	}
 
 	// grant function invoke access to the gmail sync function
-	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", cf.Name, fullSync.Name), &cloudrunv2.ServiceIamMemberArgs{
+	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", name, fullSync.Name), &cloudrunv2.ServiceIamMemberArgs{
 		Project:  pulumi.String(*i.Project.ProjectId),
 		Location: pulumi.String(DefaultRegion),
 		Name:     pulumi.String(fullSync.Name),
@@ -749,7 +749,7 @@ func (i *Infra) recruiterGmailPushNotifications(fullSync *CloudFunction) (*Cloud
 	}
 
 	// grant function invoke access to the gmail sync function
-	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", cf.Name, fullSync.Name), &cloudrunv2.ServiceIamMemberArgs{
+	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", name, fullSync.Name), &cloudrunv2.ServiceIamMemberArgs{
 		Project:  pulumi.String(*i.Project.ProjectId),
 		Location: pulumi.String(DefaultRegion),
 		Name:     pulumi.String(fullSync.Name),

--- a/deploy/cloudfunction.go
+++ b/deploy/cloudfunction.go
@@ -39,11 +39,6 @@ func (i *Infra) createCloudFunctions() error {
 		return err
 	}
 
-	_, err = i.candidateGmailPushNotifications(syncCF)
-	if err != nil {
-		return err
-	}
-
 	// grant email push notification function invoke access to the sync function
 	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", emailPushNotify.Name, syncCF.Name), &cloudrunv2.ServiceIamMemberArgs{
 		Project:  pulumi.String(*i.Project.ProjectId),
@@ -59,6 +54,16 @@ func (i *Infra) createCloudFunctions() error {
 			emailPushNotify.Function,
 		}))
 
+	if err != nil {
+		return err
+	}
+
+	_, err = i.candidateGmailPushNotifications(syncCF)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.recruiterGmailPushNotifications(syncCF)
 	if err != nil {
 		return err
 	}
@@ -391,7 +396,11 @@ func (i *Infra) candidateGmailPushNotifications(fullSync *CloudFunction) (*Cloud
 				"SENTRY_DSN":                i.config.RequireSecret("SENTRY_DSN"),
 				"TRIGGER_FULL_SYNC_URL":     fullSync.Function.ServiceConfig.Uri().Elem(),
 				"GCP_PROJECT_ID":            pulumi.String(*i.Project.ProjectId),
+				// TODO: Delete this
 				"CANDIDATE_GMAIL_MESSAGES_TOPIC": i.Topics.CandidateGmailMessages.Name.ApplyT(func(name string) string {
+					return name
+				}).(pulumi.StringOutput),
+				"GMAIL_MESSAGES_TOPIC": i.Topics.CandidateGmailMessages.Name.ApplyT(func(name string) string {
 					return name
 				}).(pulumi.StringOutput),
 			},
@@ -637,6 +646,123 @@ func (i *Infra) recruiterGmailMessages() (*CloudFunction, error) {
 	}
 
 	// allow it to selectively re-push messages that fail
+	_, err = pubsub.NewTopicIAMMember(i.ctx, fmt.Sprintf("%s-publish-to-recruiter-gmail-messages", name), &pubsub.TopicIAMMemberArgs{
+		Topic:   i.Topics.RecruiterGmailMessages.ID(),
+		Role:    pulumi.String("roles/pubsub.publisher"),
+		Member:  pulumi.Sprintf("serviceAccount:%s", sa.Email),
+		Project: pulumi.String(*i.Project.ProjectId),
+	}, pulumi.DependsOn([]pulumi.Resource{
+		cf,
+		sa,
+		i.Topics.RecruiterGmailMessages,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	return &CloudFunction{
+		Name:           name,
+		ServiceAccount: sa,
+		Function:       cf,
+		Service:        srv,
+	}, nil
+}
+
+func (i *Infra) recruiterGmailPushNotifications(fullSync *CloudFunction) (*CloudFunction, error) {
+	name := "recruiter-gmail-push-notifications"
+	sa, err := i.createCloudFunctionServiceAccount(name)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := i.uploadCloudFunction(name, "")
+	if err != nil {
+		return nil, err
+	}
+
+	cf, err := cloudfunctionsv2.NewFunction(i.ctx, name, &cloudfunctionsv2.FunctionArgs{
+		Name: pulumi.String(name),
+		// use the same location as the bucket
+		Location:    pulumi.String(DefaultRegion),
+		Project:     pulumi.String(*i.Project.ProjectId),
+		Description: pulumi.String("Handle recruiter gmail push notifications"),
+		BuildConfig: &cloudfunctionsv2.FunctionBuildConfigArgs{
+			Runtime:    pulumi.String("go119"),
+			EntryPoint: pulumi.String("Handler"),
+			EnvironmentVariables: pulumi.StringMap{
+				// Use hash to force redeploy when code changes
+				"FUNCTION_NAME":         pulumi.String(name),
+				"FUNCTION_CONTENT_HASH": obj.Md5hash,
+			},
+			Source: &cloudfunctionsv2.FunctionBuildConfigSourceArgs{
+				StorageSource: &cloudfunctionsv2.FunctionBuildConfigSourceStorageSourceArgs{
+					Bucket: i.GCFBucket.Name,
+					Object: obj.Name,
+				},
+			},
+		},
+		ServiceConfig: &cloudfunctionsv2.FunctionServiceConfigArgs{
+			AvailableMemory:  pulumi.String("256M"),
+			MinInstanceCount: pulumi.Int(0),
+			MaxInstanceCount: pulumi.Int(25),
+			TimeoutSeconds:   pulumi.Int(MaxEventArcTriggerTimeout),
+			EnvironmentVariables: pulumi.StringMap{
+				"SUPABASE_API_URL":          pulumi.String(i.config.Require("SUPABASE_API_URL")),
+				"SUPABASE_API_KEY":          i.config.RequireSecret("SUPABASE_API_KEY"),
+				"GOOGLE_OAUTH2_CREDENTIALS": i.config.RequireSecret("GOOGLE_OAUTH2_CREDENTIALS"),
+				"SENTRY_DSN":                i.config.RequireSecret("SENTRY_DSN"),
+				"TRIGGER_FULL_SYNC_URL":     fullSync.Function.ServiceConfig.Uri().Elem(),
+				"GCP_PROJECT_ID":            pulumi.String(*i.Project.ProjectId),
+				"GMAIL_MESSAGES_TOPIC": i.Topics.RecruiterGmailMessages.Name.ApplyT(func(name string) string {
+					return name
+				}).(pulumi.StringOutput),
+			},
+			IngressSettings:            pulumi.String("ALLOW_INTERNAL_ONLY"),
+			AllTrafficOnLatestRevision: pulumi.Bool(true),
+			ServiceAccountEmail:        sa.Email,
+		},
+		EventTrigger: &cloudfunctionsv2.FunctionEventTriggerArgs{
+			TriggerRegion: pulumi.String(DefaultRegion),
+			PubsubTopic:   i.Topics.RecruiterGmailSubscription.ID(),
+			EventType:     pulumi.String("google.cloud.pubsub.topic.v1.messagePublished"),
+			// Disable retry
+			RetryPolicy:         pulumi.String("RETRY_POLICY_DO_NOT_RETRY"),
+			ServiceAccountEmail: sa.Email,
+		},
+	}, pulumi.DependsOn([]pulumi.Resource{
+		i.Topics.RecruiterGmailSubscription,
+		i.Topics.RecruiterGmailMessages,
+		obj,
+		sa,
+		fullSync.Function,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	srv, err := cloudrun.LookupService(i.ctx, &cloudrun.LookupServiceArgs{
+		Name:     name,
+		Location: DefaultRegion,
+		Project:  i.Project.ProjectId,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// grant function invoke access to the gmail sync function
+	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", cf.Name, fullSync.Name), &cloudrunv2.ServiceIamMemberArgs{
+		Project:  pulumi.String(*i.Project.ProjectId),
+		Location: pulumi.String(DefaultRegion),
+		Name:     pulumi.String(fullSync.Name),
+		Role:     pulumi.String("roles/run.invoker"),
+		Member: sa.Email.ApplyT(func(email string) (string, error) {
+			return fmt.Sprintf("serviceAccount:%v", email), nil
+		}).(pulumi.StringOutput),
+	},
+		pulumi.DependsOn([]pulumi.Resource{
+			fullSync.Function,
+			cf,
+		}))
+
 	_, err = pubsub.NewTopicIAMMember(i.ctx, fmt.Sprintf("%s-publish-to-recruiter-gmail-messages", name), &pubsub.TopicIAMMemberArgs{
 		Topic:   i.Topics.RecruiterGmailMessages.ID(),
 		Role:    pulumi.String("roles/pubsub.publisher"),

--- a/deploy/cloudfunction.go
+++ b/deploy/cloudfunction.go
@@ -53,7 +53,6 @@ func (i *Infra) createCloudFunctions() error {
 			syncCF.Function,
 			emailPushNotify.Function,
 		}))
-
 	if err != nil {
 		return err
 	}
@@ -450,6 +449,9 @@ func (i *Infra) candidateGmailPushNotifications(fullSync *CloudFunction) (*Cloud
 			fullSync.Function,
 			cf,
 		}))
+	if err != nil {
+		return nil, err
+	}
 
 	_, err = pubsub.NewTopicIAMMember(i.ctx, fmt.Sprintf("%s-publish-to-candidate-gmail-messages", name), &pubsub.TopicIAMMemberArgs{
 		Topic:   i.Topics.CandidateGmailMessages.ID(),
@@ -762,6 +764,9 @@ func (i *Infra) recruiterGmailPushNotifications(fullSync *CloudFunction) (*Cloud
 			fullSync.Function,
 			cf,
 		}))
+	if err != nil {
+		return nil, err
+	}
 
 	_, err = pubsub.NewTopicIAMMember(i.ctx, fmt.Sprintf("%s-publish-to-recruiter-gmail-messages", name), &pubsub.TopicIAMMemberArgs{
 		Topic:   i.Topics.RecruiterGmailMessages.ID(),

--- a/deploy/cloudfunction.go
+++ b/deploy/cloudfunction.go
@@ -800,7 +800,7 @@ func (i *Infra) watchCandidateEmails() (*CloudFunction, error) {
 			MaxInstanceCount: pulumi.Int(1),
 			TimeoutSeconds:   pulumi.Int(MaxHTTPTriggerTimeout),
 			EnvironmentVariables: pulumi.StringMap{
-				"PUBSUB_TOPIC":              i.Topics.Gmail.ID(),
+				"PUBSUB_TOPIC":              i.Topics.CandidateGmailMessages.ID(),
 				"SUPABASE_API_URL":          pulumi.String(i.config.Require("SUPABASE_API_URL")),
 				"SUPABASE_API_KEY":          i.config.RequireSecret("SUPABASE_API_KEY"),
 				"GOOGLE_OAUTH2_CREDENTIALS": i.config.RequireSecret("GOOGLE_OAUTH2_CREDENTIALS"),
@@ -812,7 +812,7 @@ func (i *Infra) watchCandidateEmails() (*CloudFunction, error) {
 			ServiceAccountEmail:        sa.Email,
 		},
 	}, pulumi.DependsOn([]pulumi.Resource{
-		i.Topics.Gmail,
+		i.Topics.CandidateGmailMessages,
 		obj,
 		sa,
 	}))

--- a/deploy/cloudfunction.go
+++ b/deploy/cloudfunction.go
@@ -39,6 +39,11 @@ func (i *Infra) createCloudFunctions() error {
 		return err
 	}
 
+	_, err = i.candidateGmailPushNotifications(syncCF)
+	if err != nil {
+		return err
+	}
+
 	// grant email push notification function invoke access to the sync function
 	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", emailPushNotify.Name, syncCF.Name), &cloudrunv2.ServiceIamMemberArgs{
 		Project:  pulumi.String(*i.Project.ProjectId),
@@ -319,6 +324,123 @@ func (i *Infra) emailPushNotificationCF(fullSync *CloudFunction) (*CloudFunction
 	if err != nil {
 		return nil, err
 	}
+
+	_, err = pubsub.NewTopicIAMMember(i.ctx, fmt.Sprintf("%s-publish-to-candidate-gmail-messages", name), &pubsub.TopicIAMMemberArgs{
+		Topic:   i.Topics.CandidateGmailMessages.ID(),
+		Role:    pulumi.String("roles/pubsub.publisher"),
+		Member:  pulumi.Sprintf("serviceAccount:%s", sa.Email),
+		Project: pulumi.String(*i.Project.ProjectId),
+	}, pulumi.DependsOn([]pulumi.Resource{
+		cf,
+		sa,
+		i.Topics.CandidateGmailMessages,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	return &CloudFunction{
+		Name:           name,
+		ServiceAccount: sa,
+		Function:       cf,
+		Service:        srv,
+	}, nil
+}
+
+func (i *Infra) candidateGmailPushNotifications(fullSync *CloudFunction) (*CloudFunction, error) {
+	name := "candidate-gmail-push-notifications"
+	sa, err := i.createCloudFunctionServiceAccount(name)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := i.uploadCloudFunction(name, "")
+	if err != nil {
+		return nil, err
+	}
+
+	cf, err := cloudfunctionsv2.NewFunction(i.ctx, name, &cloudfunctionsv2.FunctionArgs{
+		Name: pulumi.String(name),
+		// use the same location as the bucket
+		Location:    pulumi.String(DefaultRegion),
+		Project:     pulumi.String(*i.Project.ProjectId),
+		Description: pulumi.String("Handle candidate gmail push notifications"),
+		BuildConfig: &cloudfunctionsv2.FunctionBuildConfigArgs{
+			Runtime:    pulumi.String("go119"),
+			EntryPoint: pulumi.String("Handler"),
+			EnvironmentVariables: pulumi.StringMap{
+				// Use hash to force redeploy when code changes
+				"FUNCTION_NAME":         pulumi.String(name),
+				"FUNCTION_CONTENT_HASH": obj.Md5hash,
+			},
+			Source: &cloudfunctionsv2.FunctionBuildConfigSourceArgs{
+				StorageSource: &cloudfunctionsv2.FunctionBuildConfigSourceStorageSourceArgs{
+					Bucket: i.GCFBucket.Name,
+					Object: obj.Name,
+				},
+			},
+		},
+		ServiceConfig: &cloudfunctionsv2.FunctionServiceConfigArgs{
+			AvailableMemory:  pulumi.String("256M"),
+			MinInstanceCount: pulumi.Int(0),
+			MaxInstanceCount: pulumi.Int(25),
+			TimeoutSeconds:   pulumi.Int(MaxEventArcTriggerTimeout),
+			EnvironmentVariables: pulumi.StringMap{
+				"SUPABASE_API_URL":          pulumi.String(i.config.Require("SUPABASE_API_URL")),
+				"SUPABASE_API_KEY":          i.config.RequireSecret("SUPABASE_API_KEY"),
+				"GOOGLE_OAUTH2_CREDENTIALS": i.config.RequireSecret("GOOGLE_OAUTH2_CREDENTIALS"),
+				"SENTRY_DSN":                i.config.RequireSecret("SENTRY_DSN"),
+				"TRIGGER_FULL_SYNC_URL":     fullSync.Function.ServiceConfig.Uri().Elem(),
+				"GCP_PROJECT_ID":            pulumi.String(*i.Project.ProjectId),
+				"CANDIDATE_GMAIL_MESSAGES_TOPIC": i.Topics.CandidateGmailMessages.Name.ApplyT(func(name string) string {
+					return name
+				}).(pulumi.StringOutput),
+			},
+			IngressSettings:            pulumi.String("ALLOW_INTERNAL_ONLY"),
+			AllTrafficOnLatestRevision: pulumi.Bool(true),
+			ServiceAccountEmail:        sa.Email,
+		},
+		EventTrigger: &cloudfunctionsv2.FunctionEventTriggerArgs{
+			TriggerRegion: pulumi.String(DefaultRegion),
+			PubsubTopic:   i.Topics.CandidateGmailSubscription.ID(),
+			EventType:     pulumi.String("google.cloud.pubsub.topic.v1.messagePublished"),
+			// Disable retry
+			RetryPolicy:         pulumi.String("RETRY_POLICY_DO_NOT_RETRY"),
+			ServiceAccountEmail: sa.Email,
+		},
+	}, pulumi.DependsOn([]pulumi.Resource{
+		i.Topics.CandidateGmailSubscription,
+		i.Topics.CandidateGmailMessages,
+		obj,
+		sa,
+		fullSync.Function,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	srv, err := cloudrun.LookupService(i.ctx, &cloudrun.LookupServiceArgs{
+		Name:     name,
+		Location: DefaultRegion,
+		Project:  i.Project.ProjectId,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// grant function invoke access to the gmail sync function
+	_, err = cloudrunv2.NewServiceIamMember(i.ctx, fmt.Sprintf("%s-can-invoke-%s", cf.Name, fullSync.Name), &cloudrunv2.ServiceIamMemberArgs{
+		Project:  pulumi.String(*i.Project.ProjectId),
+		Location: pulumi.String(DefaultRegion),
+		Name:     pulumi.String(fullSync.Name),
+		Role:     pulumi.String("roles/run.invoker"),
+		Member: sa.Email.ApplyT(func(email string) (string, error) {
+			return fmt.Sprintf("serviceAccount:%v", email), nil
+		}).(pulumi.StringOutput),
+	},
+		pulumi.DependsOn([]pulumi.Resource{
+			fullSync.Function,
+			cf,
+		}))
 
 	_, err = pubsub.NewTopicIAMMember(i.ctx, fmt.Sprintf("%s-publish-to-candidate-gmail-messages", name), &pubsub.TopicIAMMemberArgs{
 		Topic:   i.Topics.CandidateGmailMessages.ID(),

--- a/deploy/cloudfunction_test.go
+++ b/deploy/cloudfunction_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestShortenAcountId(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "noop",
+			input: "sa-cf-normal-length",
+			want:  "sa-cf-normal-length",
+		},
+		{
+			name:  "shorten",
+			input: "sa-cf-very-very-long-service-account-name",
+			want:  "sa-cf-very-very-long-service-a",
+		},
+		{
+			name:  "replace common names",
+			input: "sa-cf-candidate-recruiter-gmail",
+			want:  "sa-cf-ca-re-gm",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := shortenAccountId(tc.input)
+			if got != tc.want {
+				t.Errorf("ShortenAccountId(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION

<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->
Relates to #92

### Description

Deploys separate gmail push notification handlers in parallel with the existing `email_push_notification`.

### Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
