### PR TITLE
Create Separate @SRC Labels for Recruiters

### DIFF
--- a/libs/src/mail/gmail/gmail.go
+++ b/libs/src/mail/gmail/gmail.go
@@ -145,7 +145,14 @@ func (s *Service) CreateLabel(l *gmail.Label) (*gmail.Label, error) {
 
 // GetOrCreateSRCLabels fetches or creates all of the labels managed by SRC
 // Label IDs are unique to each gmail account, so we need to list all labels and match based off names.
+// DEPRECATED: Use GetOrCreateCandidateLabels instead
 func (s *Service) GetOrCreateSRCLabels() (*srclabel.Labels, error) {
+	return s.GetOrCreateCandidateLabels()
+}
+
+// GetOrCreateCandidateLabels fetches or creates all of the labels managed by SRC
+// Label IDs are unique to each gmail account, so we need to list all labels and match based off names.
+func (s *Service) GetOrCreateCandidateLabels() (*srclabel.Labels, error) {
 	// TODO: What is a better data structure or interface to make this function more DRY?
 	// list all labels
 	labels, err := s.ListLabels()
@@ -224,7 +231,6 @@ func (s *Service) GetOrCreateSRCLabels() (*srclabel.Labels, error) {
 		if err != nil {
 			return nil, err
 		}
-
 	}
 	if result.BlockSender == nil {
 		result.BlockSender, err = s.CreateLabel(&srclabel.BlockSender)
@@ -240,6 +246,54 @@ func (s *Service) GetOrCreateSRCLabels() (*srclabel.Labels, error) {
 	}
 	if result.BlockGraveyard == nil {
 		result.BlockGraveyard, err = s.CreateLabel(&srclabel.BlockGraveyard)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &result, nil
+}
+
+// GetOrCreateRecruiterLabels fetches or creates all of the labels managed by SRC
+// Label IDs are unique to each gmail account, so we need to list all labels and match based off names.
+func (s *Service) GetOrCreateRecruiterLabels() (*srclabel.RecruiterLabels, error) {
+	// TODO: What is a better data structure or interface to make this function more DRY?
+	// list all labels
+	labels, err := s.ListLabels()
+	if err != nil {
+		return nil, err
+	}
+	result := srclabel.RecruiterLabels{}
+
+	// for each label,
+	// if it exists, add it to the struct
+	// if it doesn't exist, create it and add it to the struct
+	for _, label := range labels.Labels {
+		switch label.Name {
+		case srclabel.SRC.Name:
+			result.SRC = label
+		case srclabel.Recruiting.Name:
+			result.Recruiting = label
+		case srclabel.RecruitingOutbound.Name:
+			result.RecruitingOutbound = label
+		}
+	}
+
+	// create any labels that don't exist
+	if result.SRC == nil {
+		result.SRC, err = s.CreateLabel(&srclabel.SRC)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if result.Recruiting == nil {
+		result.Recruiting, err = s.CreateLabel(&srclabel.Recruiting)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if result.RecruitingOutbound == nil {
+		result.RecruitingOutbound, err = s.CreateLabel(&srclabel.RecruitingOutbound)
 		if err != nil {
 			return nil, err
 		}

--- a/libs/src/mail/gmail/label/candidate.go
+++ b/libs/src/mail/gmail/label/candidate.go
@@ -1,0 +1,54 @@
+package label
+
+import (
+	"google.golang.org/api/gmail/v1"
+)
+
+// CandidateLabels contains all labels managed by @SRC for candidates.
+// IDs are unique per gmail account.
+// The rest of the fields should be the same across all accounts.
+type CandidateLabels struct {
+	// SRC is the @SRC parent label for all @SRC labels.
+	SRC *gmail.Label
+	// Jobs is the @SRC/Jobs folder for all @SRC job labels.
+	Jobs *gmail.Label
+	// JobsOpportunity is the @SRC/Jobs/Opportunity label for identified job opportunities.
+	JobsOpportunity *gmail.Label
+	// Allow is the @SRC/Allow folder for senders and domains that always bypass SRC
+	Allow *gmail.Label
+	// AllowSender is the @SRC/Allow/Sender folder for senders that always bypass SRC
+	AllowSender *gmail.Label
+	// AllowDomain is the @SRC/Allow/Domain folder for email domains that always bypass SRC
+	AllowDomain *gmail.Label
+	// Block is the @SRC/Allow folder for senders and domains that are automatically removed from your inbox.
+	// Blocked emails are not analyzed by SRC.
+	Block *gmail.Label
+	// BlockSender is the @SRC/Block/Sender folder for senders that are automatically removed from your inbox.
+	// Blocked emails are not analyzed by SRC.
+	BlockSender *gmail.Label
+	// BlockDomain is the @SRC/Block/Domain folder for email domains that are automatically removed from your inbox.
+	// Blocked emails are not analyzed by SRC.
+	BlockDomain *gmail.Label
+	// BlockGraveyard is the @SRC/Block/🪦 folder for emails that have been removed from your inbox.
+	// Blocked emails are not be analyzed by SRC.
+	BlockGraveyard *gmail.Label
+}
+
+// Candidate-specific labels
+var (
+	// Jobs is the @SRC/Jobs folder for all @SRC job labels.
+	Jobs = gmail.Label{
+		Name: SRC.Name + "/Jobs",
+		// Hide folder labels
+		MessageListVisibility: "hide",
+		Color:                 SRC.Color,
+	}
+	// JobsOpportunity is the @SRC/Jobs/Opportunity label for identified job opportunities.
+	JobsOpportunity = gmail.Label{
+		Name: Jobs.Name + "/Opportunity",
+		// Show leaf labels
+		MessageListVisibility: "show",
+		// use same color as parent
+		Color: Jobs.Color,
+	}
+)

--- a/libs/src/mail/gmail/label/label.go
+++ b/libs/src/mail/gmail/label/label.go
@@ -7,6 +7,8 @@ import (
 // Labels contains all labels managed by @SRC.
 // IDs are unique per gmail account.
 // The rest of the fields should be the same across all accounts.
+//
+// TODO: Merge with CandidateLabels & RecruiterLabels.
 type Labels struct {
 	// SRC is the @SRC parent label for all @SRC labels.
 	SRC *gmail.Label
@@ -45,21 +47,6 @@ var (
 			BackgroundColor: "#4986e7",
 			TextColor:       "#ffffff",
 		},
-	}
-	// Jobs is the @SRC/Jobs folder for all @SRC job labels.
-	Jobs = gmail.Label{
-		Name: SRC.Name + "/Jobs",
-		// Hide folder labels
-		MessageListVisibility: "hide",
-		Color:                 SRC.Color,
-	}
-	// JobsOpportunity is the @SRC/Jobs/Opportunity label for identified job opportunities.
-	JobsOpportunity = gmail.Label{
-		Name: Jobs.Name + "/Opportunity",
-		// Show leaf labels
-		MessageListVisibility: "show",
-		// use same color as parent
-		Color: Jobs.Color,
 	}
 	// Allow is the @SRC/Allow folder for senders and domains that always bypass SRC
 	Allow = gmail.Label{

--- a/libs/src/mail/gmail/label/recruiter.go
+++ b/libs/src/mail/gmail/label/recruiter.go
@@ -1,0 +1,34 @@
+package label
+
+import "google.golang.org/api/gmail/v1"
+
+// RecruiterLabels contains all labels managed by @SRC for recruiters..
+// IDs are unique per gmail account.
+// The rest of the fields should be the same across all accounts.
+type RecruiterLabels struct {
+	// SRC is the @SRC parent label for all @SRC labels.
+	SRC *gmail.Label
+	// Recruiting is the @SRC/Recruiting folder for all @SRC job labels.
+	Recruiting *gmail.Label
+	// RecruitingOutbound is the @SRC/Recruiting/Outbound label for identified recruiting outbound.
+	RecruitingOutbound *gmail.Label
+}
+
+// Recruiter-specific labels
+var (
+	// Recruiting is the @SRC/Recruiting folder for all @SRC managed recruiting labels.
+	Recruiting = gmail.Label{
+		Name: SRC.Name + "/Recruiting",
+		// Hide folder labels
+		MessageListVisibility: "hide",
+		Color:                 SRC.Color,
+	}
+	// RecruitingOutbound is the @SRC/Jobs/Opportunity label for identified recruiting outbound..
+	RecruitingOutbound = gmail.Label{
+		Name: Recruiting.Name + "/Outbound",
+		// Show leaf labels
+		MessageListVisibility: "show",
+		// use same color as parent
+		Color: Recruiting.Color,
+	}
+)


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

### Description

Recruiters need different labels to candidates. This starts making a distinction. Will follow up with a PR to migrate all of the existing call sites.

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
