### PR TITLE
Add Email to User OAuth Token Table

### DIFF
--- a/cloudfunctions/adhoc/reclassify.go
+++ b/cloudfunctions/adhoc/reclassify.go
@@ -110,6 +110,7 @@ func reclassify(w http.ResponseWriter, r *http.Request) {
 				// update the user's oauth token
 				err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 					UserID:   userToken.UserID,
+					Email:    userToken.Email,
 					Provider: provider,
 					Token:    userToken.Token,
 					IsValid:  false,

--- a/cloudfunctions/adhoc/unsubscribe.go
+++ b/cloudfunctions/adhoc/unsubscribe.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"gopkg.in/guregu/null.v4"
 
 	"google.golang.org/api/gmail/v1"
 
@@ -80,6 +81,7 @@ func (cf *CloudFunction) stop(users []db.UserOauthToken) []error {
 				// update the user's oauth token
 				err = cf.Queries.UpsertUserOAuthToken(cf.ctx, db.UpsertUserOAuthTokenParams{
 					UserID:   user.UserID,
+					Email:    null.StringFrom(gmailProfile.EmailAddress),
 					Provider: provider,
 					Token:    user.Token,
 					IsValid:  false,

--- a/cloudfunctions/candidate_email_sync/cloudfunction.go
+++ b/cloudfunctions/candidate_email_sync/cloudfunction.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/getsentry/sentry-go"
+	"gopkg.in/guregu/null.v4"
 
 	"cloud.google.com/go/pubsub"
 	"google.golang.org/api/gmail/v1"
@@ -114,6 +115,7 @@ func NewCloudFunction(ctx context.Context, payload EmailSyncRequest) (*CloudFunc
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
+				Email:    null.StringFrom(payload.Email),
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/candidate_gmail_messages/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_messages/cloudfunction.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/idtoken"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/shared-recruiting-co/shared-recruiting-co/libs/src/db"
 	srcmail "github.com/shared-recruiting-co/shared-recruiting-co/libs/src/mail/gmail"
@@ -157,6 +158,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailMessages) (*Cloud
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
+				Email:    null.StringFrom(payload.Email),
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/candidate_gmail_push_notifications/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_push_notifications/cloudfunction.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -106,6 +107,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailPushNotification)
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
+				Email:    null.StringFrom(payload.Email),
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/gmail_subscription/cloudfunction.go
+++ b/cloudfunctions/gmail_subscription/cloudfunction.go
@@ -103,6 +103,7 @@ func (cf *CloudFunction) watch(users []db.UserOauthToken, arg *gmail.WatchReques
 				// update the user's oauth token
 				err = cf.queries.UpsertUserOAuthToken(cf.ctx, db.UpsertUserOAuthTokenParams{
 					UserID:   user.UserID,
+					Email:    user.Email,
 					Provider: provider,
 					Token:    user.Token,
 					IsValid:  false,

--- a/cloudfunctions/populate_jobs/cloudfunction.go
+++ b/cloudfunctions/populate_jobs/cloudfunction.go
@@ -163,6 +163,7 @@ func populateJobs(w http.ResponseWriter, r *http.Request) {
 				// update the user's oauth token
 				err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 					UserID:   userToken.UserID,
+					Email:    userToken.Email,
 					Provider: provider,
 					Token:    userToken.Token,
 					IsValid:  false,

--- a/cloudfunctions/recruiter_email_sync/cloudfunction.go
+++ b/cloudfunctions/recruiter_email_sync/cloudfunction.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/getsentry/sentry-go"
+	"gopkg.in/guregu/null.v4"
 
 	"cloud.google.com/go/pubsub"
 	"google.golang.org/api/gmail/v1"
@@ -115,6 +116,7 @@ func NewCloudFunction(ctx context.Context, payload EmailSyncRequest) (*CloudFunc
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
+				Email:    null.StringFrom(payload.Email),
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/recruiter_gmail_push_notifications/cloudfunction.go
+++ b/cloudfunctions/recruiter_gmail_push_notifications/cloudfunction.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -106,6 +107,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailPushNotification)
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
+				Email:    null.StringFrom(payload.Email),
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/libs/src/db/models.go
+++ b/libs/src/db/models.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	null "gopkg.in/guregu/null.v4"
 )
 
 type InboxType string
@@ -62,6 +63,7 @@ type AuthUser struct {
 
 type CandidateOauthToken struct {
 	UserID    uuid.UUID       `json:"user_id"`
+	Email     null.String     `json:"email"`
 	Provider  string          `json:"provider"`
 	Token     json.RawMessage `json:"token"`
 	IsValid   bool            `json:"is_valid"`
@@ -100,6 +102,7 @@ type Recruiter struct {
 
 type RecruiterOauthToken struct {
 	UserID    uuid.UUID       `json:"user_id"`
+	Email     null.String     `json:"email"`
 	Provider  string          `json:"provider"`
 	Token     json.RawMessage `json:"token"`
 	IsValid   bool            `json:"is_valid"`
@@ -141,6 +144,7 @@ type UserEmailSyncHistory struct {
 
 type UserOauthToken struct {
 	UserID    uuid.UUID       `json:"user_id"`
+	Email     null.String     `json:"email"`
 	Provider  string          `json:"provider"`
 	Token     json.RawMessage `json:"token"`
 	IsValid   bool            `json:"is_valid"`

--- a/libs/src/db/query.sql
+++ b/libs/src/db/query.sql
@@ -15,6 +15,7 @@ where email = $1;
 -- name: ListUserOAuthTokens :many
 select
     user_id,
+    email,
     provider,
     token,
     is_valid,
@@ -46,6 +47,7 @@ offset $4;
 -- name: GetUserOAuthToken :one
 select
     user_id,
+    email,
     provider,
     token,
     is_valid,
@@ -55,10 +57,11 @@ from public.user_oauth_token
 where user_id = $1 and provider = $2;
 
 -- name: UpsertUserOAuthToken :exec
-insert into public.user_oauth_token (user_id, provider, token, is_valid)
-values ($1, $2, $3, $4)
+insert into public.user_oauth_token (user_id, email, provider, token, is_valid)
+values ($1, $2, $3, $4, $5)
 on conflict (user_id, provider)
 do update set
+    email = excluded.email,
     token = excluded.token,
     is_valid = excluded.is_valid;
 

--- a/libs/src/db/schema.sql
+++ b/libs/src/db/schema.sql
@@ -22,6 +22,8 @@ commit;
 -- User OAuth Token Table
 create table public.user_oauth_token (
     user_id uuid references auth.users(id) on delete cascade not null,
+    -- temporarily null until we backfill
+    email text,
     provider text not null,
     token jsonb not null,
     is_valid boolean not null default true,

--- a/libs/src/go.mod
+++ b/libs/src/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/api v0.107.0
+	gopkg.in/guregu/null.v4 v4.0.0
 )
 
 require (

--- a/libs/src/go.sum
+++ b/libs/src/go.sum
@@ -137,6 +137,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/guregu/null.v4 v4.0.0 h1:1Wm3S1WEA2I26Kq+6vcW+w0gcDo44YKYD7YIEJNHDjg=
+gopkg.in/guregu/null.v4 v4.0.0/go.mod h1:YoQhUrADuG3i9WqesrCmpNRwm1ypAgSHYqoOcTu/JrI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/web/src/lib/supabase/types.ts
+++ b/web/src/lib/supabase/types.ts
@@ -208,6 +208,7 @@ export interface Database {
 			user_oauth_token: {
 				Row: {
 					created_at: string;
+					email: string | null;
 					is_valid: boolean;
 					provider: string;
 					token: Json;
@@ -216,6 +217,7 @@ export interface Database {
 				};
 				Insert: {
 					created_at?: string;
+					email?: string | null;
 					is_valid?: boolean;
 					provider: string;
 					token: Json;
@@ -224,6 +226,7 @@ export interface Database {
 				};
 				Update: {
 					created_at?: string;
+					email?: string | null;
 					is_valid?: boolean;
 					provider?: string;
 					token?: Json;

--- a/web/supabase/migrations/20230220235803_add_email_to_user_oauth_token.sql
+++ b/web/supabase/migrations/20230220235803_add_email_to_user_oauth_token.sql
@@ -1,0 +1,3 @@
+alter table "public"."user_oauth_token" add column "email" text;
+
+


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->
Relates to #49

### Description

Adds an `email` column to the `user_oauth_token` table. Next we need to populate the field, then update all the Get callsites to include email in the request.

### Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
