### PR TITLE
Support Multiple Emails per Account (Backend)

### DIFF
--- a/cloudfunctions/adhoc/populate_jobs.go
+++ b/cloudfunctions/adhoc/populate_jobs.go
@@ -79,6 +79,7 @@ func populateJobs(w http.ResponseWriter, r *http.Request) {
 	// Get User' OAuth Token
 	userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
 		UserID:   user.UserID,
+		Email:    data.Email,
 		Provider: provider,
 	})
 	if err != nil {

--- a/cloudfunctions/adhoc/reclassify.go
+++ b/cloudfunctions/adhoc/reclassify.go
@@ -82,16 +82,6 @@ func reclassify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, userToken := range userTokens {
-		// Get User' OAuth Token
-		userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
-			UserID:   userToken.UserID,
-			Provider: provider,
-		})
-		if err != nil {
-			handleError(w, "error getting user oauth token", err)
-			return
-		}
-
 		// Create Gmail Service
 		auth := []byte(userToken.Token)
 		srv, err := srcmail.NewService(ctx, creds, auth)

--- a/cloudfunctions/adhoc/unsubscribe.go
+++ b/cloudfunctions/adhoc/unsubscribe.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"gopkg.in/guregu/null.v4"
 
 	"google.golang.org/api/gmail/v1"
 
@@ -81,7 +80,7 @@ func (cf *CloudFunction) stop(users []db.UserOauthToken) []error {
 				// update the user's oauth token
 				err = cf.Queries.UpsertUserOAuthToken(cf.ctx, db.UpsertUserOAuthTokenParams{
 					UserID:   user.UserID,
-					Email:    null.StringFrom(gmailProfile.EmailAddress),
+					Email:    gmailProfile.EmailAddress,
 					Provider: provider,
 					Token:    user.Token,
 					IsValid:  false,

--- a/cloudfunctions/candidate_email_sync/cloudfunction.go
+++ b/cloudfunctions/candidate_email_sync/cloudfunction.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/getsentry/sentry-go"
-	"gopkg.in/guregu/null.v4"
 
 	"cloud.google.com/go/pubsub"
 	"google.golang.org/api/gmail/v1"
@@ -87,6 +86,7 @@ func NewCloudFunction(ctx context.Context, payload EmailSyncRequest) (*CloudFunc
 	// 2. Get User' OAuth Token
 	userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
 		UserID:   user.UserID,
+		Email:    payload.Email,
 		Provider: provider,
 	})
 	if err != nil {
@@ -115,7 +115,7 @@ func NewCloudFunction(ctx context.Context, payload EmailSyncRequest) (*CloudFunc
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
-				Email:    null.StringFrom(payload.Email),
+				Email:    payload.Email,
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/candidate_gmail_messages/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_messages/cloudfunction.go
@@ -14,7 +14,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/idtoken"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/shared-recruiting-co/shared-recruiting-co/libs/src/db"
 	srcmail "github.com/shared-recruiting-co/shared-recruiting-co/libs/src/mail/gmail"
@@ -130,6 +129,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailMessages) (*Cloud
 	// 2. Get User' OAuth Token
 	userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
 		UserID:   user.UserID,
+		Email:    payload.Email,
 		Provider: provider,
 	})
 	if err != nil {
@@ -158,7 +158,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailMessages) (*Cloud
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
-				Email:    null.StringFrom(payload.Email),
+				Email:    payload.Email,
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/candidate_gmail_push_notifications/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_push_notifications/cloudfunction.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -79,6 +78,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailPushNotification)
 	// 2. Get User' OAuth Token
 	userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
 		UserID:   user.UserID,
+		Email:    payload.Email,
 		Provider: provider,
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailPushNotification)
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
-				Email:    null.StringFrom(payload.Email),
+				Email:    payload.Email,
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/populate_jobs/cloudfunction.go
+++ b/cloudfunctions/populate_jobs/cloudfunction.go
@@ -138,16 +138,6 @@ func populateJobs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, userToken := range userTokens {
-		// Get User' OAuth Token
-		userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
-			UserID:   userToken.UserID,
-			Provider: provider,
-		})
-		if err != nil {
-			handleError(w, "error getting user oauth token", err)
-			return
-		}
-
 		// Create Gmail Service
 		auth := []byte(userToken.Token)
 		srv, err := srcmail.NewService(ctx, creds, auth)

--- a/cloudfunctions/recruiter_email_sync/cloudfunction.go
+++ b/cloudfunctions/recruiter_email_sync/cloudfunction.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/getsentry/sentry-go"
-	"gopkg.in/guregu/null.v4"
 
 	"cloud.google.com/go/pubsub"
 	"google.golang.org/api/gmail/v1"
@@ -88,6 +87,7 @@ func NewCloudFunction(ctx context.Context, payload EmailSyncRequest) (*CloudFunc
 	// 2. Get User' OAuth Token
 	userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
 		UserID:   user.UserID,
+		Email:    payload.Email,
 		Provider: provider,
 	})
 	if err != nil {
@@ -116,7 +116,7 @@ func NewCloudFunction(ctx context.Context, payload EmailSyncRequest) (*CloudFunc
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
-				Email:    null.StringFrom(payload.Email),
+				Email:    payload.Email,
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/cloudfunctions/recruiter_gmail_messages/cloudfunction.go
+++ b/cloudfunctions/recruiter_gmail_messages/cloudfunction.go
@@ -71,6 +71,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailMessages) (*Cloud
 	// 2. Get User' OAuth Token
 	userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
 		UserID:   user.UserID,
+		Email:    payload.Email,
 		Provider: provider,
 	})
 	if err != nil {

--- a/cloudfunctions/recruiter_gmail_push_notifications/cloudfunction.go
+++ b/cloudfunctions/recruiter_gmail_push_notifications/cloudfunction.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -79,6 +78,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailPushNotification)
 	// 2. Get User' OAuth Token
 	userToken, err := queries.GetUserOAuthToken(ctx, db.GetUserOAuthTokenParams{
 		UserID:   user.UserID,
+		Email:    payload.Email,
 		Provider: provider,
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailPushNotification)
 			// update the user's oauth token
 			err = queries.UpsertUserOAuthToken(ctx, db.UpsertUserOAuthTokenParams{
 				UserID:   userToken.UserID,
-				Email:    null.StringFrom(payload.Email),
+				Email:    payload.Email,
 				Provider: provider,
 				Token:    userToken.Token,
 				IsValid:  false,

--- a/libs/src/db/http.go
+++ b/libs/src/db/http.go
@@ -86,8 +86,8 @@ func singleOrError[T any](slice []T) (T, error) {
 
 // GetUserProfileByEmail fetches a user profile by email.
 func (q *HTTPQueries) GetUserProfileByEmail(ctx context.Context, email string) (UserProfile, error) {
-	basePath := "/user_profile"
-	query := fmt.Sprintf("select=*&email=eq.%s", email)
+	basePath := "/rpc/get_user_profile_by_email"
+	query := fmt.Sprintf("input=%s", email)
 	path := fmt.Sprintf("%s?%s", basePath, query)
 	var result UserProfile
 
@@ -448,8 +448,8 @@ func (q *HTTPQueries) CountUserEmailJobs(ctx context.Context, userID uuid.UUID) 
 
 // GetRecruiterByEmail fetches a recruiter profile given their email
 func (q *HTTPQueries) GetRecruiterByEmail(ctx context.Context, email string) (GetRecruiterByEmailRow, error) {
-	basePath := "/recruiter"
-	query := fmt.Sprintf("select=*&email=eq.%s", email)
+	basePath := "/rpc/get_recruiter_by_email"
+	query := fmt.Sprintf("input=%s", email)
 	path := fmt.Sprintf("%s?%s", basePath, query)
 	var result GetRecruiterByEmailRow
 

--- a/libs/src/db/http.go
+++ b/libs/src/db/http.go
@@ -139,7 +139,7 @@ func (q *HTTPQueries) GetUserEmailSyncHistory(ctx context.Context, arg GetUserEm
 // GetUserOAuthToken fetches a user's oauth token.
 func (q *HTTPQueries) GetUserOAuthToken(ctx context.Context, arg GetUserOAuthTokenParams) (UserOauthToken, error) {
 	basePath := "/user_oauth_token"
-	query := fmt.Sprintf("select=*&user_id=eq.%s&provider=eq.%s", arg.UserID, arg.Provider)
+	query := fmt.Sprintf("select=*&user_id=eq.%s&email=eq.%s&provider=eq.%s", arg.UserID, arg.Email, arg.Provider)
 	path := fmt.Sprintf("%s?%s", basePath, query)
 	var result UserOauthToken
 

--- a/libs/src/db/models.go
+++ b/libs/src/db/models.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	null "gopkg.in/guregu/null.v4"
 )
 
 type InboxType string
@@ -63,7 +62,7 @@ type AuthUser struct {
 
 type CandidateOauthToken struct {
 	UserID    uuid.UUID       `json:"user_id"`
-	Email     null.String     `json:"email"`
+	Email     string          `json:"email"`
 	Provider  string          `json:"provider"`
 	Token     json.RawMessage `json:"token"`
 	IsValid   bool            `json:"is_valid"`
@@ -102,7 +101,7 @@ type Recruiter struct {
 
 type RecruiterOauthToken struct {
 	UserID    uuid.UUID       `json:"user_id"`
-	Email     null.String     `json:"email"`
+	Email     string          `json:"email"`
 	Provider  string          `json:"provider"`
 	Token     json.RawMessage `json:"token"`
 	IsValid   bool            `json:"is_valid"`
@@ -144,7 +143,7 @@ type UserEmailSyncHistory struct {
 
 type UserOauthToken struct {
 	UserID    uuid.UUID       `json:"user_id"`
-	Email     null.String     `json:"email"`
+	Email     string          `json:"email"`
 	Provider  string          `json:"provider"`
 	Token     json.RawMessage `json:"token"`
 	IsValid   bool            `json:"is_valid"`

--- a/libs/src/db/query.sql
+++ b/libs/src/db/query.sql
@@ -1,16 +1,17 @@
 -- name: GetUserProfileByEmail :one
 select
-    user_id,
-    email,
-    first_name,
-    last_name,
-    is_active,
-    auto_archive,
-    auto_contribute,
-    created_at,
-    updated_at
+    user_profile.user_id,
+    user_profile.email,
+    user_profile.first_name,
+    user_profile.last_name,
+    user_profile.is_active,
+    user_profile.auto_archive,
+    user_profile.auto_contribute,
+    user_profile.created_at,
+    user_profile.updated_at
 from public.user_profile
-where email = $1;
+inner join public.user_oauth_token using (user_id)
+where user_profile.email = $1 OR user_oauth_token.email = $1;
 
 -- name: ListUserOAuthTokens :many
 select
@@ -54,14 +55,13 @@ select
     created_at,
     updated_at
 from public.user_oauth_token
-where user_id = $1 and provider = $2;
+where user_id = $1 and email = $2 and provider = $3;
 
 -- name: UpsertUserOAuthToken :exec
 insert into public.user_oauth_token (user_id, email, provider, token, is_valid)
 values ($1, $2, $3, $4, $5)
-on conflict (user_id, provider)
+on conflict (user_id, email, provider)
 do update set
-    email = excluded.email,
     token = excluded.token,
     is_valid = excluded.is_valid;
 
@@ -136,12 +136,13 @@ where user_id = $1;
 
 -- name: GetRecruiterByEmail :one
 select 
-    user_id,
-    email,
-    first_name,
-    last_name,
-    company_id,
-    created_at,
-    updated_at
+    recruiter.user_id,
+    recruiter.email,
+    recruiter.first_name,
+    recruiter.last_name,
+    recruiter.company_id,
+    recruiter.created_at,
+    recruiter.updated_at
 from recruiter
-where email = $1;
+inner join public.user_oauth_token using (user_id)
+where recruiter.email = $1 OR user_oauth_token.email = $1;

--- a/libs/src/db/query.sql.go
+++ b/libs/src/db/query.sql.go
@@ -28,15 +28,16 @@ func (q *Queries) CountUserEmailJobs(ctx context.Context, userID uuid.UUID) (int
 
 const getRecruiterByEmail = `-- name: GetRecruiterByEmail :one
 select 
-    user_id,
-    email,
-    first_name,
-    last_name,
-    company_id,
-    created_at,
-    updated_at
+    recruiter.user_id,
+    recruiter.email,
+    recruiter.first_name,
+    recruiter.last_name,
+    recruiter.company_id,
+    recruiter.created_at,
+    recruiter.updated_at
 from recruiter
-where email = $1
+inner join public.user_oauth_token using (user_id)
+where recruiter.email = $1 OR user_oauth_token.email = $1
 `
 
 type GetRecruiterByEmailRow struct {
@@ -168,17 +169,18 @@ func (q *Queries) GetUserOAuthToken(ctx context.Context, arg GetUserOAuthTokenPa
 
 const getUserProfileByEmail = `-- name: GetUserProfileByEmail :one
 select
-    user_id,
-    email,
-    first_name,
-    last_name,
-    is_active,
-    auto_archive,
-    auto_contribute,
-    created_at,
-    updated_at
+    user_profile.user_id,
+    user_profile.email,
+    user_profile.first_name,
+    user_profile.last_name,
+    user_profile.is_active,
+    user_profile.auto_archive,
+    user_profile.auto_contribute,
+    user_profile.created_at,
+    user_profile.updated_at
 from public.user_profile
-where email = $1
+inner join public.user_oauth_token using (user_id)
+where user_profile.email = $1 OR user_oauth_token.email = $1
 `
 
 func (q *Queries) GetUserProfileByEmail(ctx context.Context, email string) (UserProfile, error) {

--- a/libs/src/db/schema.sql
+++ b/libs/src/db/schema.sql
@@ -342,3 +342,25 @@ select
   user_oauth_token.*
 from user_oauth_token
 inner join recruiter using (user_id);
+
+create or replace function get_user_profile_by_email (input text)
+returns user_profile as 
+$$
+select
+  user_profile.*
+from public.user_profile
+inner join public.user_oauth_token using (user_id)
+where user_profile.email = input OR user_oauth_token.email = input;
+$$
+language sql stable;
+
+create or replace function get_recruiter_by_email (input text)
+returns recruiter as 
+$$
+select
+  recruiter.*
+from public.recruiter
+inner join public.user_oauth_token using (user_id)
+where recruiter.email = input OR user_oauth_token.email = input;
+$$
+language sql stable;

--- a/libs/src/db/schema.sql
+++ b/libs/src/db/schema.sql
@@ -22,15 +22,14 @@ commit;
 -- User OAuth Token Table
 create table public.user_oauth_token (
     user_id uuid references auth.users(id) on delete cascade not null,
-    -- temporarily null until we backfill
-    email text,
+    email text not null,
     provider text not null,
     token jsonb not null,
     is_valid boolean not null default true,
     created_at timestamp with time zone not null default now(),
     updated_at timestamp with time zone not null default now(),
 
-    primary key (user_id, provider)
+    primary key (user_id, email, provider)
 );
 
 create trigger handle_updated_at_user_oauth_token before update on public.user_oauth_token

--- a/libs/src/go.mod
+++ b/libs/src/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/api v0.107.0
-	gopkg.in/guregu/null.v4 v4.0.0
 )
 
 require (

--- a/libs/src/go.sum
+++ b/libs/src/go.sum
@@ -137,8 +137,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/guregu/null.v4 v4.0.0 h1:1Wm3S1WEA2I26Kq+6vcW+w0gcDo44YKYD7YIEJNHDjg=
-gopkg.in/guregu/null.v4 v4.0.0/go.mod h1:YoQhUrADuG3i9WqesrCmpNRwm1ypAgSHYqoOcTu/JrI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/web/src/lib/server/google/gmail.ts
+++ b/web/src/lib/server/google/gmail.ts
@@ -1,5 +1,5 @@
 import { dev } from '$app/environment';
-import { NEW_EMAIL_PUBSUB_TOPIC } from '$env/static/private';
+import { CANDIDATE_GMAIL_PUBSUB_TOPIC } from '$env/static/private';
 
 // Until we have a better local development and testing story,
 // We will always return true for dev
@@ -19,7 +19,7 @@ export const watch = async (accessToken: string) =>
 					// TODO: Parameterize once we have use cases for multiple topics or labels
 					labelIds: ['UNREAD'],
 					labelFilterAction: 'include',
-					topicName: NEW_EMAIL_PUBSUB_TOPIC
+					topicName: CANDIDATE_GMAIL_PUBSUB_TOPIC
 				})
 		  });
 

--- a/web/src/lib/supabase/types.ts
+++ b/web/src/lib/supabase/types.ts
@@ -208,7 +208,7 @@ export interface Database {
 			user_oauth_token: {
 				Row: {
 					created_at: string;
-					email: string | null;
+					email: string;
 					is_valid: boolean;
 					provider: string;
 					token: Json;
@@ -217,7 +217,7 @@ export interface Database {
 				};
 				Insert: {
 					created_at?: string;
-					email?: string | null;
+					email: string;
 					is_valid?: boolean;
 					provider: string;
 					token: Json;
@@ -226,7 +226,7 @@ export interface Database {
 				};
 				Update: {
 					created_at?: string;
-					email?: string | null;
+					email?: string;
 					is_valid?: boolean;
 					provider?: string;
 					token?: Json;

--- a/web/src/routes/api/account/gmail/connect/+server.ts
+++ b/web/src/routes/api/account/gmail/connect/+server.ts
@@ -68,19 +68,13 @@ const connectEmail = async ({
 
 	// verify emails match
 	const { email } = idTokenPayload;
-	if (email !== session.user.email) {
-		console.log('authorized user does not match session user');
-		throw error(
-			400,
-			`You must connect with the same email as your SRC account. Please connect with ${session.user.email}`
-		);
-	}
 
 	// save oauth tokens
 	console.log('saving user oauth token...');
 	// format tokens for db
 	const { error: tokenSaveError } = await supabaseClient.from('user_oauth_token').upsert({
 		user_id: session.user.id,
+		email,
 		provider: 'google',
 		token: {
 			access_token,

--- a/web/supabase/migrations/20230221003612_multi_email_user_oauth_token_pk.sql
+++ b/web/supabase/migrations/20230221003612_multi_email_user_oauth_token_pk.sql
@@ -8,4 +8,24 @@ CREATE UNIQUE INDEX user_oauth_token_pkey ON public.user_oauth_token USING btree
 
 alter table "public"."user_oauth_token" add constraint "user_oauth_token_pkey" PRIMARY KEY using index "user_oauth_token_pkey";
 
+create or replace function get_user_profile_by_email (input text)
+returns user_profile as 
+$$
+select
+  user_profile.*
+from public.user_profile
+inner join public.user_oauth_token using (user_id)
+where user_profile.email = input OR user_oauth_token.email = input;
+$$
+language sql stable;
 
+create or replace function get_recruiter_by_email (input text)
+returns recruiter as 
+$$
+select
+  recruiter.*
+from public.recruiter
+inner join public.user_oauth_token using (user_id)
+where recruiter.email = input OR user_oauth_token.email = input;
+$$
+language sql stable;

--- a/web/supabase/migrations/20230221003612_multi_email_user_oauth_token_pk.sql
+++ b/web/supabase/migrations/20230221003612_multi_email_user_oauth_token_pk.sql
@@ -1,0 +1,11 @@
+alter table "public"."user_oauth_token" drop constraint "user_oauth_token_pkey";
+
+drop index if exists "public"."user_oauth_token_pkey";
+
+alter table "public"."user_oauth_token" alter column "email" set not null;
+
+CREATE UNIQUE INDEX user_oauth_token_pkey ON public.user_oauth_token USING btree (user_id, email, provider);
+
+alter table "public"."user_oauth_token" add constraint "user_oauth_token_pkey" PRIMARY KEY using index "user_oauth_token_pkey";
+
+


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->
Relates to #49

### Description

- Updates the PK of `user_oauth_token` to allow for multiple emails per user and provider. 
- Updates references in Cloud Functions

This doesn't update the frontend, so from end-users perspectives nothing has changed.

### Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
