### PR TITLE
Add Empty States to Job Details Page

### DIFF
--- a/web/src/routes/(app)/recruiter/(account)/jobs/[id]/+page.svelte
+++ b/web/src/routes/(app)/recruiter/(account)/jobs/[id]/+page.svelte
@@ -10,16 +10,13 @@
 	$: ({ job, candidates, outboundTemplates } = data);
 	$: hash = $page.url.hash || '#candidates';
 
-	//
-
 	// TODO
 	// Edit Job
 	// Delete Job
-	// Empty State
 </script>
 
 <nav class="flex" aria-label="Breadcrumb">
-	<ol role="list" class="flex items-center space-x-4">
+	<ol class="flex items-center space-x-4">
 		<li>
 			<div class="flex items-center">
 				<a href="/recruiter/jobs" class="text-sm font-medium text-slate-500 hover:text-slate-700"

--- a/web/src/routes/(app)/recruiter/(account)/jobs/[id]/+page.ts
+++ b/web/src/routes/(app)/recruiter/(account)/jobs/[id]/+page.ts
@@ -6,10 +6,10 @@ import type { Database } from '$lib/supabase/types';
 type Data = {
 	job: Database['public']['Tables']['job']['Row'];
 	candidates: Database['public']['Tables']['candidate_company_inbound']['Row'][];
-	outboundTemplates: Database['public']['Tables']['recruiter_outbound_template']['Row'];
+	outboundTemplates: Database['public']['Tables']['recruiter_outbound_template']['Row'][];
 };
 
-export const load: PageLoad = async ({ params, parent }) => {
+export const load: PageLoad<Data> = async ({ params, parent }) => {
 	const { id: jobID } = params;
 	const { supabase } = await parent();
 
@@ -26,22 +26,21 @@ export const load: PageLoad = async ({ params, parent }) => {
 	if (jobErr) throw error(500, jobErr);
 
 	// TODO: Pagination!
-
-	// get all the candidates for a job
-	const { data: candidates, error: candidatesErr } = await supabase
-		.from('candidate_company_inbound')
-		.select('*')
-		.eq('job_id', jobID);
+	let [
+		// eslint-disable-next-line
+		{ data: candidates = [], error: candidatesErr },
+		// eslint-disable-next-line
+		{ data: outboundTemplates, error: outboundTemplateErr }
+	] = await Promise.all([
+		supabase.from('candidate_company_inbound').select('*').eq('job_id', jobID),
+		supabase.from('recruiter_outbound_template').select('*').eq('job_id', jobID)
+	]);
 
 	if (candidatesErr) throw error(500, candidatesErr);
-	console.log(candidates);
-
-	const { data: outboundTemplates, error: outboundTemplateErr } = await supabase
-		.from('recruiter_outbound_template')
-		.select('*')
-		.eq('job_id', jobID);
+	if (!candidates) candidates = [];
 
 	if (outboundTemplateErr) throw error(500, outboundTemplateErr);
+	if (!outboundTemplates) outboundTemplates = [];
 
 	return {
 		job,

--- a/web/src/routes/(app)/recruiter/(account)/jobs/[id]/+page.ts
+++ b/web/src/routes/(app)/recruiter/(account)/jobs/[id]/+page.ts
@@ -13,7 +13,6 @@ export const load: PageLoad<Data> = async ({ params, parent }) => {
 	const { id: jobID } = params;
 	const { supabase } = await parent();
 
-	// TODO: Use Promise.all() to get all the data at once
 	const { data: job, error: jobErr } = await supabase
 		.from('job')
 		.select('*')
@@ -25,7 +24,9 @@ export const load: PageLoad<Data> = async ({ params, parent }) => {
 	}
 	if (jobErr) throw error(500, jobErr);
 
-	// TODO: Pagination!
+	// TODO:
+	// Pagination!
+	// Recipient Counts
 	let [
 		// eslint-disable-next-line
 		{ data: candidates = [], error: candidatesErr },

--- a/web/src/routes/(app)/recruiter/(account)/jobs/[id]/Candidates.svelte
+++ b/web/src/routes/(app)/recruiter/(account)/jobs/[id]/Candidates.svelte
@@ -2,6 +2,9 @@
 	import type { Database } from '$lib/supabase/types';
 
 	export let candidates: Database['public']['Tables']['candidate_company_inbound']['Row'][];
+
+	// TODO
+	// What columns do we want to show?
 </script>
 
 <div>
@@ -57,7 +60,7 @@
 							<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3">
 								{new Date(candidate.updated_at).toLocaleDateString()}
 							</td>
-							<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3"> todo </td>
+							<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3" />
 						</tr>
 					{/each}
 				</tbody>

--- a/web/src/routes/(app)/recruiter/(account)/jobs/[id]/Candidates.svelte
+++ b/web/src/routes/(app)/recruiter/(account)/jobs/[id]/Candidates.svelte
@@ -1,40 +1,67 @@
 <script lang="ts">
-	// TODO: Type
-	export let candidates: any[];
+	import type { Database } from '$lib/supabase/types';
+
+	export let candidates: Database['public']['Tables']['candidate_company_inbound']['Row'][];
 </script>
 
 <div>
-	<div class="mt-8 overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 md:mx-0">
-		<table class="min-w-full divide-y divide-slate-300">
-			<thead class="bg-slate-50 text-left text-sm">
-				<tr>
-					<th
-						scope="col"
-						class="hidden py-3.5 pl-4 pr-3 font-semibold text-slate-900 sm:pl-6 lg:table-cell"
-						>Candidate</th
-					>
-					<th scope="col" class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
-						>Last Activity</th
-					>
-					<th
-						scope="col"
-						class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
-					/>
-				</tr>
-			</thead>
-			<tbody class="divide-y divide-slate-200 bg-white">
-				{#each candidates as candidate}
-					<tr class="text-sm text-slate-700">
-						<td class="hidden py-4 pl-4 pr-3 font-medium text-slate-900 sm:pl-6 lg:table-cell">
-							{candidate.candidate_email}
-						</td>
-						<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3">
-							{new Date(candidate.updated_at).toLocaleDateString()}
-						</td>
-						<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3"> todo </td>
+	<!-- Empty State -->
+	{#if candidates.length === 0}
+		<div class="flex flex-col items-center justify-center p-8">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke-width="1.5"
+				stroke="currentColor"
+				class="h-12 w-12 text-slate-400"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
+				/>
+			</svg>
+
+			<p class="mt-2 font-medium text-slate-900">No Candidates</p>
+			<p class="mt-1 max-w-md text-center text-sm text-slate-500">
+				SRC automatically imports candidates you reach out. Any candidate you reach out to with an
+				outboudn template associated with the job will show up here.
+			</p>
+		</div>
+	{:else}
+		<div class="mt-8 overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 md:mx-0">
+			<table class="min-w-full divide-y divide-slate-300">
+				<thead class="bg-slate-50 text-left text-sm">
+					<tr>
+						<th
+							scope="col"
+							class="hidden py-3.5 pl-4 pr-3 font-semibold text-slate-900 sm:pl-6 lg:table-cell"
+							>Candidate</th
+						>
+						<th scope="col" class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
+							>Last Activity</th
+						>
+						<th
+							scope="col"
+							class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
+						/>
 					</tr>
-				{/each}
-			</tbody>
-		</table>
-	</div>
+				</thead>
+				<tbody class="divide-y divide-slate-200 bg-white">
+					{#each candidates as candidate}
+						<tr class="text-sm text-slate-700">
+							<td class="hidden py-4 pl-4 pr-3 font-medium text-slate-900 sm:pl-6 lg:table-cell">
+								{candidate.candidate_email}
+							</td>
+							<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3">
+								{new Date(candidate.updated_at).toLocaleDateString()}
+							</td>
+							<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3"> todo </td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
 </div>

--- a/web/src/routes/(app)/recruiter/(account)/jobs/[id]/OutboundTemplates.svelte
+++ b/web/src/routes/(app)/recruiter/(account)/jobs/[id]/OutboundTemplates.svelte
@@ -1,55 +1,82 @@
 <script lang="ts">
-	// TODO: Type
-	export let outboundTemplates: any[];
+	import type { Database } from '$lib/supabase/types';
+
+	export let outboundTemplates: Database['public']['Tables']['recruiter_outbound_template']['Row'][];
 </script>
 
 <div>
-	<div class="mt-8 overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 md:mx-0">
-		<table class="min-w-full divide-y divide-slate-300">
-			<thead class="bg-slate-50 text-left text-sm">
-				<tr>
-					<th
-						scope="col"
-						class="hidden py-3.5 pl-4 pr-3 font-semibold text-slate-900 sm:pl-6 lg:table-cell"
-						>Subject</th
-					>
-					<th scope="col" class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
-						>Body</th
-					>
-					<th
-						scope="col"
-						class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
-					/>
-				</tr>
-			</thead>
-			<tbody class="divide-y divide-slate-200 bg-white">
-				{#each outboundTemplates as outbound}
-					<tr class="text-sm text-slate-700">
-						<td class="hidden py-4 pl-4 pr-3 font-medium text-slate-900 sm:pl-6 lg:table-cell">
-							{outbound.subject}
-						</td>
-						<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3">
-							{outbound.body.slice(0, 40)}...
-						</td>
-						<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3">
-							<div class="flex flex-row items-center text-slate-500">
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									viewBox="0 0 20 20"
-									fill="currentColor"
-									class="mr-1 h-5 w-5"
-								>
-									<path
-										d="M10 8a3 3 0 100-6 3 3 0 000 6zM3.465 14.493a1.23 1.23 0 00.41 1.412A9.957 9.957 0 0010 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 00-13.074.003z"
-									/>
-								</svg>
-
-								<span> 2 </span>
-							</div>
-						</td>
+	<!-- Empty State -->
+	{#if outboundTemplates.length === 0}
+		<div class="flex flex-col items-center justify-center p-8">
+			<svg
+				class="h-12 w-12 text-slate-400"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke-width="1.5"
+				stroke="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+				/>
+			</svg>
+			<p class="mt-2 font-medium text-slate-900">No Outbound Templates Assigned</p>
+			<p class="mt-1 max-w-md text-center text-sm text-slate-500">
+				<a href="/recruiter/outbound" class="underline hover:text-blue-500"
+					>Assign outbound templates</a
+				> to this job to import candidates into SRC.
+			</p>
+		</div>
+	{:else}
+		<div class="mt-8 overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 md:mx-0">
+			<table class="min-w-full divide-y divide-slate-300">
+				<thead class="bg-slate-50 text-left text-sm">
+					<tr>
+						<th
+							scope="col"
+							class="hidden py-3.5 pl-4 pr-3 font-semibold text-slate-900 sm:pl-6 lg:table-cell"
+							>Subject</th
+						>
+						<th scope="col" class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
+							>Body</th
+						>
+						<th
+							scope="col"
+							class="table-cell py-3.5 pl-4 pr-3 font-semibold text-slate-900 lg:px-3"
+						/>
 					</tr>
-				{/each}
-			</tbody>
-		</table>
-	</div>
+				</thead>
+				<tbody class="divide-y divide-slate-200 bg-white">
+					{#each outboundTemplates as outbound}
+						<tr class="text-sm text-slate-700">
+							<td class="hidden py-4 pl-4 pr-3 font-medium text-slate-900 sm:pl-6 lg:table-cell">
+								{outbound.subject}
+							</td>
+							<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3">
+								{outbound.body.slice(0, 40)}...
+							</td>
+							<td class="table-cell py-4 pl-4 pr-3 font-medium text-slate-900 lg:px-3">
+								<div class="flex flex-row items-center text-slate-500">
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										viewBox="0 0 20 20"
+										fill="currentColor"
+										class="mr-1 h-5 w-5"
+									>
+										<path
+											d="M10 8a3 3 0 100-6 3 3 0 000 6zM3.465 14.493a1.23 1.23 0 00.41 1.412A9.957 9.957 0 0010 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 00-13.074.003z"
+										/>
+									</svg>
+
+									<span> 2 </span>
+								</div>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

### Description

Adds a simple empty state for the two tabs on the candidate page. Also uses promise.all to parallelize data loading

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [x] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
