### PR TITLE
feat: init helper test functions for pgTap

### DIFF
--- a/web/supabase/tests/database/0_setup.test.sql
+++ b/web/supabase/tests/database/0_setup.test.sql
@@ -1,0 +1,51 @@
+create or replace procedure auth.login_as_user(user_email text)
+    language plpgsql
+    as $$
+declare
+    auth_user auth.users;
+begin
+    select
+        * into auth_user
+    from
+        auth.users
+    where
+        email = user_email;
+    execute format('set request.jwt.claim.sub=%L', (auth_user).id::text);
+    execute format('set request.jwt.claim.role=%I', (auth_user).role);
+    execute format('set request.jwt.claim.email=%L', (auth_user).email);
+    execute format('set request.jwt.claims=%L', json_strip_nulls(json_build_object('app_metadata', (auth_user).raw_app_meta_data))::text);
+    raise notice '%', format( 'set role %I; -- logging in as %L (%L)', (auth_user).role, (auth_user).id, (auth_user).email);
+    execute format('set role %I', (auth_user).role);
+end;
+$$;
+
+create or replace procedure auth.login_as_anon()
+    language plpgsql
+    as $$
+begin
+    set request.jwt.claim.sub='';
+    set request.jwt.claim.role='';
+    set request.jwt.claim.email='';
+    set request.jwt.claims='';
+    set role anon;
+end;
+$$;
+
+create or replace procedure auth.logout()
+    language plpgsql
+    as $$
+begin
+    set request.jwt.claim.sub='';
+    set request.jwt.claim.role='';
+    set request.jwt.claim.email='';
+    set request.jwt.claims='';
+    set role postgres;
+end;
+$$;
+
+-- pg_tap complains if there are no tests
+begin;
+select plan( 1 );
+select ok( true, 'canary' );
+select * from finish();
+rollback;

--- a/web/supabase/tests/database/canary.test.sql
+++ b/web/supabase/tests/database/canary.test.sql
@@ -21,5 +21,9 @@ SELECT has_column(
     'id should exist'
 );
 
+-- check helper functions are available
+call auth.login_as_anon();
+call auth.logout();
+
 select * from finish();
 rollback;


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

### Description

There is no native setup functionality, but currently Supabase or pgTap loads files alphabetically. We take advantage of that by prefixing the file with `0_`

Credit to https://blog.mansueli.com/using-custom-claims-testing-rls-with-supabase#heading-using-the-helpers-to-simulate-login-and-rls-policies for the auth helper functions

### Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested these changes
- [x] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
