### PR TITLE
feat: fetch email label changes from history

### DIFF
--- a/cloudfunctions/candidate_gmail_push_notifications/email.go
+++ b/cloudfunctions/candidate_gmail_push_notifications/email.go
@@ -4,18 +4,29 @@ import (
 	"google.golang.org/api/gmail/v1"
 
 	srcmail "github.com/shared-recruiting-co/shared-recruiting-co/libs/src/mail/gmail"
+	"github.com/shared-recruiting-co/shared-recruiting-co/libs/src/pubsub/schema"
 )
 
 const maxResults = 250
 const historyTypeMessageAdded = "messageAdded"
 
-func fetchNewEmailsSinceHistoryID(srv *srcmail.Service, historyID uint64, pageToken string) ([]*gmail.Message, string, error) {
+var (
+	// historyTypes is a list of all the history types that we want to fetch.
+	// We don't care about deleted messages.
+	// See https://developers.google.com/gmail/api/v1/reference/users/history/list
+	historyTypes = []string{
+		"messageAdded",
+		"labelAdded",
+		"labelRemoved",
+	}
+)
+
+func fetchChangesSinceHistoryID(srv *srcmail.Service, historyID uint64, pageToken string) ([]*gmail.History, string, error) {
 	r, err := srcmail.ExecuteWithRetries(func() (*gmail.ListHistoryResponse, error) {
 		return srv.Users.History.
 			List(srv.UserID).
-			LabelId("UNREAD").
 			StartHistoryId(historyID).
-			HistoryTypes(historyTypeMessageAdded).
+			HistoryTypes(historyTypes...).
 			PageToken(pageToken).
 			MaxResults(maxResults).
 			Do()
@@ -33,5 +44,39 @@ func fetchNewEmailsSinceHistoryID(srv *srcmail.Service, historyID uint64, pageTo
 		}
 	}
 
-	return messages, r.NextPageToken, nil
+	return r.History, r.NextPageToken, nil
+}
+
+func historyToAddedMessages(histories []*gmail.History) []*gmail.Message {
+	messages := []*gmail.Message{}
+	for _, h := range histories {
+		for _, m := range h.MessagesAdded {
+			messages = append(messages, m.Message)
+		}
+	}
+	return messages
+}
+
+func (cf *CloudFunction) historyToEmailLabelChanges(histories []*gmail.History) *schema.EmailLabelChanges {
+	changes := []schema.EmailLabelChange{}
+	for _, h := range histories {
+		for _, m := range h.LabelsAdded {
+			changes = append(changes, schema.EmailLabelChange{
+				MessageID:  m.Message.Id,
+				LabelIDs:   m.LabelIds,
+				ChangeType: schema.EmailLabelChangeTypeAdded,
+			})
+		}
+		for _, m := range h.LabelsRemoved {
+			changes = append(changes, schema.EmailLabelChange{
+				MessageID:  m.Message.Id,
+				LabelIDs:   m.LabelIds,
+				ChangeType: schema.EmailLabelChangeTypeRemoved,
+			})
+		}
+	}
+	return &schema.EmailLabelChanges{
+		Email:   cf.payload.Email,
+		Changes: &changes,
+	}
 }

--- a/cloudfunctions/candidate_gmail_push_notifications/email.go
+++ b/cloudfunctions/candidate_gmail_push_notifications/email.go
@@ -8,7 +8,6 @@ import (
 )
 
 const maxResults = 250
-const historyTypeMessageAdded = "messageAdded"
 
 var (
 	// historyTypes is a list of all the history types that we want to fetch.

--- a/cloudfunctions/candidate_gmail_push_notifications/email.go
+++ b/cloudfunctions/candidate_gmail_push_notifications/email.go
@@ -36,14 +36,6 @@ func fetchChangesSinceHistoryID(srv *srcmail.Service, historyID uint64, pageToke
 		return nil, "", err
 	}
 
-	messages := []*gmail.Message{}
-	for _, h := range r.History {
-		// only look at messages added
-		for _, m := range h.MessagesAdded {
-			messages = append(messages, m.Message)
-		}
-	}
-
 	return r.History, r.NextPageToken, nil
 }
 

--- a/libs/src/pubsub/schema/schema.go
+++ b/libs/src/pubsub/schema/schema.go
@@ -38,3 +38,23 @@ type EmailMessagesSettings struct {
 	// Reclassify indicates whether we should reclassify already classified messages or not.
 	Reclassify bool `json:"reclassify"`
 }
+
+// EmailLabelChangeTypeAdded indicates a label was added to a message
+const EmailLabelChangeTypeAdded = "added"
+
+// EmailLabelChangeTypeRemoved indicates a label was removed from a message
+const EmailLabelChangeTypeRemoved = "removed"
+
+// EmailLabelChange is the payload for a label change event
+type EmailLabelChange struct {
+	MessageID  string   `json:"message_id"`
+	LabelIDs   []string `json:"label_ids"`
+	ChangeType string   `json:"change_type"`
+}
+
+type EmailLabelChanges struct {
+	// Email is the email address of the user.
+	Email string `json:"email"`
+	// Changes is the list of label changes.
+	Changes *[]EmailLabelChange `json:"changes"`
+}


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

Relates to #159

### Description

Prep for bidirectional sync logic. In order for us to sync labels between gmail and the DB, we need to know when `@SRC` labels are removed or added.

This adds placeholder logic to publish email label changes to a separate topic for handling.

### Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
