### PR TITLE
Remove User Email Job When Gmail Label is Removed

### DIFF
--- a/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
@@ -18,6 +18,7 @@ import (
 	"github.com/shared-recruiting-co/shared-recruiting-co/libs/src/db"
 	srcmail "github.com/shared-recruiting-co/shared-recruiting-co/libs/src/mail/gmail"
 	srclabel "github.com/shared-recruiting-co/shared-recruiting-co/libs/src/mail/gmail/label"
+	srcmessage "github.com/shared-recruiting-co/shared-recruiting-co/libs/src/mail/gmail/message"
 	"github.com/shared-recruiting-co/shared-recruiting-co/libs/src/ml"
 	"github.com/shared-recruiting-co/shared-recruiting-co/libs/src/pubsub/schema"
 )
@@ -62,8 +63,8 @@ type CloudFunction struct {
 	user                 db.UserProfile
 	examplesCollectorSrv *srcmail.Service
 	payload              *schema.EmailLabelChanges
-	addedLabelFuncs      map[string]func(msg *gmail.Message) error
-	removedLabelFuncs    map[string]func(msg *gmail.Message) error
+	addedLabelFuncs      map[string]func(cf *CloudFunction, msg *gmail.Message) error
+	removedLabelFuncs    map[string]func(cf *CloudFunction, msg *gmail.Message) error
 }
 
 func NewCloudFunction(ctx context.Context, payload schema.EmailLabelChanges) (*CloudFunction, error) {
@@ -159,10 +160,10 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailLabelChanges) (*C
 
 	// set up label handlers
 	// use label IDs as keys
-	addedLabelFuncs := map[string]func(msg *gmail.Message) error{
+	addedLabelFuncs := map[string]func(cf *CloudFunction, msg *gmail.Message) error{
 		labels.JobsOpportunity.Id: handleAddedJobOpportunityLabel,
 	}
-	removedLabelFuncs := map[string]func(msg *gmail.Message) error{
+	removedLabelFuncs := map[string]func(cf *CloudFunction, msg *gmail.Message) error{
 		labels.JobsOpportunity.Id: handleRemovedJobOpportunityLabel,
 	}
 
@@ -287,7 +288,7 @@ func (cf *CloudFunction) processLabelAdded(msg *gmail.Message, labelID string) e
 		return nil
 	}
 	// 2. run the function
-	return fn(msg)
+	return fn(cf, msg)
 }
 
 func (cf *CloudFunction) processLabelRemoved(msg *gmail.Message, labelID string) error {
@@ -298,20 +299,99 @@ func (cf *CloudFunction) processLabelRemoved(msg *gmail.Message, labelID string)
 		return nil
 	}
 	// 2. run the function
-	return fn(msg)
+	return fn(cf, msg)
+}
+
+func (cf *CloudFunction) ParseEmail(msg *gmail.Message) (*ml.ParseJobResponse, error) {
+	parseRequest := ml.ParseJobRequest{
+		From:    srcmessage.Sender(msg),
+		Subject: srcmessage.Subject(msg),
+		Body:    srcmessage.Body(msg),
+	}
+	log.Printf("parsing email: %s", msg.Id)
+	return cf.model.ParseJob(&parseRequest)
+}
+
+func (cf *CloudFunction) InsertRecruiterEmailIntoDB(msg *gmail.Message, company, title, recruiter string) error {
+	recruiterEmail := srcmessage.SenderEmail(msg)
+	data := map[string]interface{}{
+		"recruiter":       recruiter,
+		"recruiter_email": recruiterEmail,
+	}
+
+	// turn data into json.RawMessage
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	// convert epoch ms to time.Time
+	emailedAt := srcmessage.CreatedAt(msg)
+	profile, err := cf.srv.Profile()
+
+	if err != nil {
+		return fmt.Errorf("error getting profile: %w", err)
+	}
+
+	return cf.queries.InsertUserEmailJob(cf.ctx, db.InsertUserEmailJobParams{
+		UserID:        cf.user.UserID,
+		UserEmail:     profile.EmailAddress,
+		EmailThreadID: msg.ThreadId,
+		EmailedAt:     emailedAt,
+		Company:       company,
+		JobTitle:      title,
+		Data:          b,
+	})
 }
 
 // Label Functions
 
-func handleAddedJobOpportunityLabel(msg *gmail.Message) error {
+// handleAddedJobOpportunityLabel handles the added job opportunities label
+// 1. check if the user has auto contribute enabled
+// 2. parse the email and add to the user's job board
+func handleAddedJobOpportunityLabel(cf *CloudFunction, msg *gmail.Message) error {
 	// For now log
 	log.Printf("added job opportunities label: %s", msg.Id)
-	// TODO
-	// process as a recruiting email
+
+	// 1. check if the user has auto contribute enabled
+	if cf.user.AutoContribute && cf.examplesCollectorSrv != nil {
+		// clone the message to the examples inbox
+		_, err := srcmail.CloneMessage(cf.srv, cf.examplesCollectorSrv, msg.Id, []string{"INBOX", "UNREAD"})
+
+		if err != nil {
+			// don't abort on error
+			log.Printf("error collecting email %s: %v", msg.Id, err)
+			sentry.CaptureException(fmt.Errorf("error collecting email %s: %w", msg.Id, err))
+		}
+	}
+
+	// 2. parse the email and add to the user's job board
+	job, err := cf.ParseEmail(msg)
+	// for now, abort on error
+	if err != nil {
+		return err
+	}
+
+	// if fields are missing, skip
+	if job.Company == "" || job.Title == "" || job.Recruiter == "" {
+		// print sender and subject
+		log.Printf("skipping job: %v", job)
+		return nil
+	}
+
+	err = cf.InsertRecruiterEmailIntoDB(msg, job.Company, job.Title, job.Recruiter)
+
+	// for now, continue on error
+	if err != nil {
+		log.Printf("error inserting job (%v): %v", job, err)
+	}
+
 	return nil
 }
 
-func handleRemovedJobOpportunityLabel(msg *gmail.Message) error {
+// handleRemovedJobOpportunityLabel handles the removed job opportunities label
+// 1. remove from a user's user_email_job if it exists
+func handleRemovedJobOpportunityLabel(cf *CloudFunction, msg *gmail.Message) error {
 	// For now log
 	log.Printf("removed job opportunities label: %s", msg.Id)
 	// TODO

--- a/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
@@ -387,7 +387,15 @@ func handleAddedJobOpportunityLabel(cf *CloudFunction, msg *gmail.Message) error
 func handleRemovedJobOpportunityLabel(cf *CloudFunction, msg *gmail.Message) error {
 	// For now log
 	log.Printf("removed job opportunities label: %s", msg.Id)
-	// TODO
+
 	// Remove from a user's user_email_job if it exists
+	err := cf.queries.DeleteUserEmailJobByEmailThreadID(cf.ctx, db.DeleteUserEmailJobByEmailThreadIDParams{
+		UserEmail:     cf.payload.Email,
+		EmailThreadID: msg.ThreadId,
+	})
+	if err != nil {
+		log.Printf("error deleting job: %v", err)
+	}
+
 	return nil
 }

--- a/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
@@ -325,22 +325,15 @@ func (cf *CloudFunction) InsertRecruiterEmailIntoDB(msg *gmail.Message, company,
 		return err
 	}
 
-	// convert epoch ms to time.Time
-	emailedAt := srcmessage.CreatedAt(msg)
-	profile, err := cf.srv.Profile()
-
-	if err != nil {
-		return fmt.Errorf("error getting profile: %w", err)
-	}
-
 	return cf.queries.InsertUserEmailJob(cf.ctx, db.InsertUserEmailJobParams{
 		UserID:        cf.user.UserID,
-		UserEmail:     profile.EmailAddress,
+		UserEmail:     cf.payload.Email,
 		EmailThreadID: msg.ThreadId,
-		EmailedAt:     emailedAt,
-		Company:       company,
-		JobTitle:      title,
-		Data:          b,
+		// convert epoch ms to time.Time
+		EmailedAt: srcmessage.CreatedAt(msg),
+		Company:   company,
+		JobTitle:  title,
+		Data:      b,
 	})
 }
 

--- a/cloudfunctions/candidate_gmail_messages/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_messages/cloudfunction.go
@@ -88,14 +88,13 @@ func isMessageBeforeReply(messages []*gmail.Message, messageID string) bool {
 }
 
 type CloudFunction struct {
-	ctx                  context.Context
-	queries              db.Querier
-	srv                  *srcmail.Service
-	labels               *srclabel.CandidateLabels
-	model                ml.Service
-	user                 db.UserProfile
-	examplesCollectorSrv *srcmail.Service
-	settings             schema.EmailMessagesSettings
+	ctx      context.Context
+	queries  db.Querier
+	srv      *srcmail.Service
+	labels   *srclabel.CandidateLabels
+	model    ml.Service
+	user     db.UserProfile
+	settings schema.EmailMessagesSettings
 }
 
 func NewCloudFunction(ctx context.Context, payload schema.EmailMessages) (*CloudFunction, error) {
@@ -113,18 +112,6 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailMessages) (*Cloud
 	user, err := queries.GetUserProfileByEmail(ctx, payload.Email)
 	if err != nil {
 		return nil, fmt.Errorf("error getting user profile by email: %w", err)
-	}
-
-	var examplesCollectorSrv *srcmail.Service
-	if user.AutoContribute {
-		auth, err := jsonFromEnv("EXAMPLES_GMAIL_OAUTH_TOKEN")
-		if err != nil {
-			return nil, fmt.Errorf("error parsing EXAMPLES_GMAIL_OAUTH_TOKEN: %w", err)
-		}
-		examplesCollectorSrv, err = srcmail.NewService(ctx, creds, auth)
-		if err != nil {
-			return nil, fmt.Errorf("error creating examples collector service: %w", err)
-		}
 	}
 
 	// 2. Get User' OAuth Token
@@ -190,14 +177,13 @@ func NewCloudFunction(ctx context.Context, payload schema.EmailMessages) (*Cloud
 	})
 
 	return &CloudFunction{
-		ctx:                  ctx,
-		queries:              queries,
-		srv:                  srv,
-		labels:               labels,
-		model:                model,
-		user:                 user,
-		examplesCollectorSrv: examplesCollectorSrv,
-		settings:             payload.Settings,
+		ctx:      ctx,
+		queries:  queries,
+		srv:      srv,
+		labels:   labels,
+		model:    model,
+		user:     user,
+		settings: payload.Settings,
 	}, nil
 }
 

--- a/libs/src/db/db.go
+++ b/libs/src/db/db.go
@@ -27,6 +27,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.countUserEmailJobsStmt, err = db.PrepareContext(ctx, countUserEmailJobs); err != nil {
 		return nil, fmt.Errorf("error preparing query CountUserEmailJobs: %w", err)
 	}
+	if q.deleteUserEmailJobByEmailThreadIDStmt, err = db.PrepareContext(ctx, deleteUserEmailJobByEmailThreadID); err != nil {
+		return nil, fmt.Errorf("error preparing query DeleteUserEmailJobByEmailThreadID: %w", err)
+	}
 	if q.getRecruiterByEmailStmt, err = db.PrepareContext(ctx, getRecruiterByEmail); err != nil {
 		return nil, fmt.Errorf("error preparing query GetRecruiterByEmail: %w", err)
 	}
@@ -89,6 +92,11 @@ func (q *Queries) Close() error {
 	if q.countUserEmailJobsStmt != nil {
 		if cerr := q.countUserEmailJobsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing countUserEmailJobsStmt: %w", cerr)
+		}
+	}
+	if q.deleteUserEmailJobByEmailThreadIDStmt != nil {
+		if cerr := q.deleteUserEmailJobByEmailThreadIDStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing deleteUserEmailJobByEmailThreadIDStmt: %w", cerr)
 		}
 	}
 	if q.getRecruiterByEmailStmt != nil {
@@ -221,6 +229,7 @@ type Queries struct {
 	db                                         DBTX
 	tx                                         *sql.Tx
 	countUserEmailJobsStmt                     *sql.Stmt
+	deleteUserEmailJobByEmailThreadIDStmt      *sql.Stmt
 	getRecruiterByEmailStmt                    *sql.Stmt
 	getRecruiterOutboundMessageStmt            *sql.Stmt
 	getRecruiterOutboundMessageByRecipientStmt *sql.Stmt
@@ -243,11 +252,12 @@ type Queries struct {
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
-		db:                              tx,
-		tx:                              tx,
-		countUserEmailJobsStmt:          q.countUserEmailJobsStmt,
-		getRecruiterByEmailStmt:         q.getRecruiterByEmailStmt,
-		getRecruiterOutboundMessageStmt: q.getRecruiterOutboundMessageStmt,
+		db:                                    tx,
+		tx:                                    tx,
+		countUserEmailJobsStmt:                q.countUserEmailJobsStmt,
+		deleteUserEmailJobByEmailThreadIDStmt: q.deleteUserEmailJobByEmailThreadIDStmt,
+		getRecruiterByEmailStmt:               q.getRecruiterByEmailStmt,
+		getRecruiterOutboundMessageStmt:       q.getRecruiterOutboundMessageStmt,
 		getRecruiterOutboundMessageByRecipientStmt: q.getRecruiterOutboundMessageByRecipientStmt,
 		getUserEmailJobStmt:                        q.getUserEmailJobStmt,
 		getUserEmailSyncHistoryStmt:                q.getUserEmailSyncHistoryStmt,

--- a/libs/src/db/http.go
+++ b/libs/src/db/http.go
@@ -436,6 +436,23 @@ func (q *HTTPQueries) InsertUserEmailJob(ctx context.Context, arg InsertUserEmai
 	return nil
 }
 
+// DeleteUserEmailJobByEmailThreadID deletes a user's email job by email thread ID.
+func (q *HTTPQueries) DeleteUserEmailJobByEmailThreadID(ctx context.Context, arg DeleteUserEmailJobByEmailThreadIDParams) error {
+	basePath := "/user_email_job"
+	query := fmt.Sprintf("user_id=eq.%s&email_thread_id=eq.%s", arg.UserEmail, arg.EmailThreadID)
+	path := fmt.Sprintf("%s?%s", basePath, query)
+
+	resp, err := q.DoRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("error deleting user email job: %s", resp.Status)
+	}
+
+	return nil
+}
+
 // CountUserEmailJobs counts the number of user's email jobs.
 func (q *HTTPQueries) CountUserEmailJobs(ctx context.Context, userID uuid.UUID) (int64, error) {
 	basePath := "/user_email_job"

--- a/libs/src/db/http.go
+++ b/libs/src/db/http.go
@@ -439,7 +439,7 @@ func (q *HTTPQueries) InsertUserEmailJob(ctx context.Context, arg InsertUserEmai
 // DeleteUserEmailJobByEmailThreadID deletes a user's email job by email thread ID.
 func (q *HTTPQueries) DeleteUserEmailJobByEmailThreadID(ctx context.Context, arg DeleteUserEmailJobByEmailThreadIDParams) error {
 	basePath := "/user_email_job"
-	query := fmt.Sprintf("user_id=eq.%s&email_thread_id=eq.%s", arg.UserEmail, arg.EmailThreadID)
+	query := fmt.Sprintf("user_email=eq.%s&email_thread_id=eq.%s", arg.UserEmail, arg.EmailThreadID)
 	path := fmt.Sprintf("%s?%s", basePath, query)
 
 	resp, err := q.DoRequest(ctx, http.MethodDelete, path, nil)

--- a/libs/src/db/querier.go
+++ b/libs/src/db/querier.go
@@ -12,6 +12,7 @@ import (
 
 type Querier interface {
 	CountUserEmailJobs(ctx context.Context, userID uuid.UUID) (int64, error)
+	DeleteUserEmailJobByEmailThreadID(ctx context.Context, arg DeleteUserEmailJobByEmailThreadIDParams) error
 	GetRecruiterByEmail(ctx context.Context, email string) (GetRecruiterByEmailRow, error)
 	GetRecruiterOutboundMessage(ctx context.Context, arg GetRecruiterOutboundMessageParams) (RecruiterOutboundMessage, error)
 	GetRecruiterOutboundMessageByRecipient(ctx context.Context, arg GetRecruiterOutboundMessageByRecipientParams) (RecruiterOutboundMessage, error)

--- a/libs/src/db/query.sql
+++ b/libs/src/db/query.sql
@@ -130,6 +130,10 @@ where job_id = $1;
 insert into public.user_email_job(user_id, user_email, email_thread_id, emailed_at, company, job_title, data)
 values ($1, $2, $3, $4, $5, $6, $7);
 
+-- name: DeleteUserEmailJobByEmailThreadID :exec
+delete from public.user_email_job
+where user_email = $1 and email_thread_id = $2;
+
 -- name: CountUserEmailJobs :one
 select count(*) as cnt
 from public.user_email_job

--- a/libs/src/db/query.sql.go
+++ b/libs/src/db/query.sql.go
@@ -26,6 +26,21 @@ func (q *Queries) CountUserEmailJobs(ctx context.Context, userID uuid.UUID) (int
 	return cnt, err
 }
 
+const deleteUserEmailJobByEmailThreadID = `-- name: DeleteUserEmailJobByEmailThreadID :exec
+delete from public.user_email_job
+where user_email = $1 and email_thread_id = $2
+`
+
+type DeleteUserEmailJobByEmailThreadIDParams struct {
+	UserEmail     string `json:"user_email"`
+	EmailThreadID string `json:"email_thread_id"`
+}
+
+func (q *Queries) DeleteUserEmailJobByEmailThreadID(ctx context.Context, arg DeleteUserEmailJobByEmailThreadIDParams) error {
+	_, err := q.exec(ctx, q.deleteUserEmailJobByEmailThreadIDStmt, deleteUserEmailJobByEmailThreadID, arg.UserEmail, arg.EmailThreadID)
+	return err
+}
+
 const getRecruiterByEmail = `-- name: GetRecruiterByEmail :one
 select 
     recruiter.user_id,


### PR DESCRIPTION
- refactor: handle job opportunities on label add
- chore: remove unused service
- fix: use payload email not profile email
- feat: add query for deleting user_email_job by (user_email, thread_id)
- feat: delete user_email_job when gmail label is removed

<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->

Relates to #159

### Description

Delete the corresponding entry to `user_email_job` when the `@SRC/Jobs/Opportunity` label is removed.

### Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
