### PR TITLE
fix: conditionally delete job interest rather than setting to null

### DIFF
--- a/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
+++ b/cloudfunctions/candidate_gmail_label_changes/cloudfunction.go
@@ -564,13 +564,10 @@ func handleRemovedJobInterestedLabel(cf *CloudFunction, msg *gmail.Message) erro
 		return nil
 	}
 
-	err = cf.queries.UpdateCandidateJobInterestConditionally(cf.ctx, db.UpdateCandidateJobInterestConditionallyParams{
+	err = cf.queries.DeleteCandidateJobInterestConditionally(cf.ctx, db.DeleteCandidateJobInterestConditionallyParams{
 		CandidateID: cf.user.UserID,
 		JobID:       *jobID,
 		Interest:    db.JobInterestInterested,
-		SetInterest: db.NullJobInterest{
-			Valid: false,
-		},
 	})
 
 	// for now, only log errors
@@ -640,13 +637,10 @@ func handleRemovedJobNotInterestedLabel(cf *CloudFunction, msg *gmail.Message) e
 		return nil
 	}
 
-	err = cf.queries.UpdateCandidateJobInterestConditionally(cf.ctx, db.UpdateCandidateJobInterestConditionallyParams{
+	err = cf.queries.DeleteCandidateJobInterestConditionally(cf.ctx, db.DeleteCandidateJobInterestConditionallyParams{
 		CandidateID: cf.user.UserID,
 		JobID:       *jobID,
 		Interest:    db.JobInterestNotInterested,
-		SetInterest: db.NullJobInterest{
-			Valid: false,
-		},
 	})
 
 	// for now, only log errors
@@ -717,13 +711,10 @@ func handleRemovedJobSavedLabel(cf *CloudFunction, msg *gmail.Message) error {
 		return nil
 	}
 
-	err = cf.queries.UpdateCandidateJobInterestConditionally(cf.ctx, db.UpdateCandidateJobInterestConditionallyParams{
+	err = cf.queries.DeleteCandidateJobInterestConditionally(cf.ctx, db.DeleteCandidateJobInterestConditionallyParams{
 		CandidateID: cf.user.UserID,
 		JobID:       *jobID,
 		Interest:    db.JobInterestSaved,
-		SetInterest: db.NullJobInterest{
-			Valid: false,
-		},
 	})
 
 	// for now, only log errors

--- a/libs/src/db/http.go
+++ b/libs/src/db/http.go
@@ -717,20 +717,12 @@ func (q *HTTPQueries) UpsertCandidateJobInterest(ctx context.Context, arg Upsert
 	return nil
 }
 
-type UpdateCandidateJobInterestBody struct {
-	Interest NullJobInterest `json:"interest"`
-}
-
-func (q *HTTPQueries) UpdateCandidateJobInterestConditionally(ctx context.Context, arg UpdateCandidateJobInterestConditionallyParams) error {
+func (q *HTTPQueries) DeleteCandidateJobInterestConditionally(ctx context.Context, arg DeleteCandidateJobInterestConditionallyParams) error {
 	basePath := "/candidate_job_interest"
 	query := fmt.Sprintf("candidate_id=eq.%s&job_id=eq.%s&interest=eq.%s", arg.CandidateID.String(), arg.JobID.String(), arg.Interest)
 	path := fmt.Sprintf("%s?%s", basePath, query)
-	body, err := json.Marshal(UpdateCandidateJobInterestBody{Interest: arg.SetInterest})
-	if err != nil {
-		return err
-	}
 
-	resp, err := q.DoRequest(ctx, http.MethodPatch, path, bytes.NewReader(body))
+	resp, err := q.DoRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return err
 	}

--- a/libs/src/db/querier.go
+++ b/libs/src/db/querier.go
@@ -12,6 +12,7 @@ import (
 
 type Querier interface {
 	CountUserEmailJobs(ctx context.Context, userID uuid.UUID) (int64, error)
+	DeleteCandidateJobInterestConditionally(ctx context.Context, arg DeleteCandidateJobInterestConditionallyParams) error
 	DeleteUserEmailJobByEmailThreadID(ctx context.Context, arg DeleteUserEmailJobByEmailThreadIDParams) error
 	GetRecruiterByEmail(ctx context.Context, email string) (GetRecruiterByEmailRow, error)
 	GetRecruiterOutboundMessage(ctx context.Context, arg GetRecruiterOutboundMessageParams) (RecruiterOutboundMessage, error)
@@ -31,7 +32,6 @@ type Querier interface {
 	ListSimilarRecruiterOutboundTemplates(ctx context.Context, arg ListSimilarRecruiterOutboundTemplatesParams) ([]ListSimilarRecruiterOutboundTemplatesRow, error)
 	ListUserEmailJobs(ctx context.Context, arg ListUserEmailJobsParams) ([]UserEmailJob, error)
 	ListUserOAuthTokens(ctx context.Context, arg ListUserOAuthTokensParams) ([]UserOauthToken, error)
-	UpdateCandidateJobInterestConditionally(ctx context.Context, arg UpdateCandidateJobInterestConditionallyParams) error
 	UpsertCandidateJobInterest(ctx context.Context, arg UpsertCandidateJobInterestParams) error
 	UpsertUserEmailSyncHistory(ctx context.Context, arg UpsertUserEmailSyncHistoryParams) error
 	UpsertUserOAuthToken(ctx context.Context, arg UpsertUserOAuthTokenParams) error

--- a/libs/src/db/query.sql
+++ b/libs/src/db/query.sql
@@ -243,7 +243,6 @@ on conflict (candidate_id, job_id)
 do update set
     interest = excluded.interest;
 
--- name: UpdateCandidateJobInterestConditionally :exec
-update public.candidate_job_interest
-set interest = sqlc.narg(set_interest)::job_interest
+-- name: DeleteCandidateJobInterestConditionally :exec
+delete from public.candidate_job_interest
 where candidate_id = $1 and job_id = $2 and interest = $3;

--- a/libs/src/db/query.sql.go
+++ b/libs/src/db/query.sql.go
@@ -26,6 +26,22 @@ func (q *Queries) CountUserEmailJobs(ctx context.Context, userID uuid.UUID) (int
 	return cnt, err
 }
 
+const deleteCandidateJobInterestConditionally = `-- name: DeleteCandidateJobInterestConditionally :exec
+delete from public.candidate_job_interest
+where candidate_id = $1 and job_id = $2 and interest = $3
+`
+
+type DeleteCandidateJobInterestConditionallyParams struct {
+	CandidateID uuid.UUID   `json:"candidate_id"`
+	JobID       uuid.UUID   `json:"job_id"`
+	Interest    JobInterest `json:"interest"`
+}
+
+func (q *Queries) DeleteCandidateJobInterestConditionally(ctx context.Context, arg DeleteCandidateJobInterestConditionallyParams) error {
+	_, err := q.exec(ctx, q.deleteCandidateJobInterestConditionallyStmt, deleteCandidateJobInterestConditionally, arg.CandidateID, arg.JobID, arg.Interest)
+	return err
+}
+
 const deleteUserEmailJobByEmailThreadID = `-- name: DeleteUserEmailJobByEmailThreadID :exec
 delete from public.user_email_job
 where user_email = $1 and email_thread_id = $2
@@ -772,29 +788,6 @@ func (q *Queries) ListUserOAuthTokens(ctx context.Context, arg ListUserOAuthToke
 		return nil, err
 	}
 	return items, nil
-}
-
-const updateCandidateJobInterestConditionally = `-- name: UpdateCandidateJobInterestConditionally :exec
-update public.candidate_job_interest
-set interest = $4::job_interest
-where candidate_id = $1 and job_id = $2 and interest = $3
-`
-
-type UpdateCandidateJobInterestConditionallyParams struct {
-	CandidateID uuid.UUID       `json:"candidate_id"`
-	JobID       uuid.UUID       `json:"job_id"`
-	Interest    JobInterest     `json:"interest"`
-	SetInterest NullJobInterest `json:"set_interest"`
-}
-
-func (q *Queries) UpdateCandidateJobInterestConditionally(ctx context.Context, arg UpdateCandidateJobInterestConditionallyParams) error {
-	_, err := q.exec(ctx, q.updateCandidateJobInterestConditionallyStmt, updateCandidateJobInterestConditionally,
-		arg.CandidateID,
-		arg.JobID,
-		arg.Interest,
-		arg.SetInterest,
-	)
-	return err
 }
 
 const upsertCandidateJobInterest = `-- name: UpsertCandidateJobInterest :exec


### PR DESCRIPTION
<!--
Fixes # (issue)
Relates to # (issue/PR)
Depends on # (issue/PR)
-->
Relates to #209

### Description

Per title. `candidate_job_interest.interest` is `not null`, so we can't set to null; instead let's delete. This is fine because we always `upsert` when adding candidate job interest.

### Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have tested these changes
- [ ] I have made corresponding changes to the documentation (if necessary)

<!-- 
### Additional Notes
-->
