### PR TITLE
Add Verified Label to Known Recruiting Emails

### DIFF
--- a/libs/src/mail/gmail/gmail.go
+++ b/libs/src/mail/gmail/gmail.go
@@ -171,6 +171,8 @@ func (s *Service) GetOrCreateCandidateLabels() (*srclabel.CandidateLabels, error
 			result.JobsNotInterested = label
 		case srclabel.JobsSaved.Name:
 			result.JobsSaved = label
+		case srclabel.JobsVerified.Name:
+			result.JobsVerified = label
 		case srclabel.Allow.Name:
 			result.Allow = label
 		case srclabel.AllowSender.Name:
@@ -221,6 +223,12 @@ func (s *Service) GetOrCreateCandidateLabels() (*srclabel.CandidateLabels, error
 	}
 	if result.JobsSaved == nil {
 		result.JobsSaved, err = s.CreateLabel(&srclabel.JobsSaved)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if result.JobsVerified == nil {
+		result.JobsVerified, err = s.CreateLabel(&srclabel.JobsVerified)
 		if err != nil {
 			return nil, err
 		}

--- a/libs/src/mail/gmail/label/candidate.go
+++ b/libs/src/mail/gmail/label/candidate.go
@@ -97,9 +97,9 @@ var (
 		Name: Jobs.Name + "/Verified",
 		// Show leaf labels
 		MessageListVisibility: "show",
-		// gray-ish black with white text
+		// teal-ish with white text
 		Color: &gmail.LabelColor{
-			BackgroundColor: "#333633",
+			BackgroundColor: "#2da2bb",
 			TextColor:       "#ffffff",
 		},
 	}

--- a/libs/src/mail/gmail/label/candidate.go
+++ b/libs/src/mail/gmail/label/candidate.go
@@ -20,6 +20,8 @@ type CandidateLabels struct {
 	JobsNotInterested *gmail.Label
 	// JobsSaved is the @SRC/Jobs/Saved label for job opportunities the candidate saved.
 	JobsSaved *gmail.Label
+	// JobsVerified is the @SRC/Jobs/Verified label for job opportunities that are sent from recruiters using SRC
+	JobsVerified *gmail.Label
 	// Allow is the @SRC/Allow folder for senders and domains that always bypass SRC
 	Allow *gmail.Label
 	// AllowSender is the @SRC/Allow/Sender folder for senders that always bypass SRC
@@ -90,8 +92,15 @@ var (
 			TextColor:       "#ffffff",
 		},
 	}
-	// TODO
 	// JobsVerified is the @SRC/Jobs/Verified label for verified job opportunities.
-	// BackgroundColor is #2da2bb
-	// TextColor is #ffffff
+	JobsVerified = gmail.Label{
+		Name: Jobs.Name + "/Verified",
+		// Show leaf labels
+		MessageListVisibility: "show",
+		// gray-ish black with white text
+		Color: &gmail.LabelColor{
+			BackgroundColor: "#333633",
+			TextColor:       "#ffffff",
+		},
+	}
 )


### PR DESCRIPTION
# Summary
- Addresses: https://github.com/shared-recruiting-co/shared-recruiting-co/issues/226
- Adds a `JobsVerified` label for emails that come from outbound SRC recruiting emails
- Label is added in the `processMessages` function of [cloudfunctions/candidate_gmail_messages/cloudfunction.go](https://github.com/shared-recruiting-co/shared-recruiting-co/compare/main...msteinbrick:shared-recruiting-co:add-verified-labels-for-official-jobs?expand=1#diff-ed0bb4e4a7e4cc1d87c8bf9863805db8e3e01713e3f3286aaaf6e6a1fdd80dd4)
- No additional bi-directional sync logic added
  - Users do not have the ability to remove verified labels in the UI, unlike the Interested / Uninterested / Saved labels
  - If a user removes a Jobs/Verified label from an email, there is no action to be taken on the DB side

# Test Plan
- [x] CI

# Reviewers
@devstein - let me know

Additionally, do you think it's worth me figuring out how to deploy these cloud functions and link them to my locally hosted SRC to test changes like this? I have not done that here